### PR TITLE
Improve navigation styling and landing-mode search behavior

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -7,7 +7,7 @@
   <!-- Главная страница -->
   <url>
     <loc>https://opensophy.com/</loc>
-    <lastmod>2026-04-23</lastmod>
+    <lastmod>2026-04-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/src/features/navigation/components/Navigation.tsx
+++ b/src/features/navigation/components/Navigation.tsx
@@ -199,14 +199,34 @@ const DocLink: React.FC<{
       style={{
         display: 'flex', alignItems: 'center', gap: '0.5rem',
         padding: mobile ? '10px 14px' : '8px 10px',
-        borderRadius: '8px', fontSize: mobile ? '1rem' : '0.875rem',
+        borderRadius: '10px', fontSize: mobile ? '1rem' : '0.875rem',
         textDecoration: 'none',
-        border: `1px solid ${isActive ? t.elevatedBorder : 'transparent'}`,
+        border: `1px solid ${isActive ? t.elevatedBorder : t.border}`,
         color: isActive ? t.accent : t.fg, fontWeight: isActive ? 600 : 400,
-        background: isActive ? t.accentSoft : 'transparent',
-        boxShadow: isActive ? t.elevatedShadowSoft : 'none',
+        background: isActive
+          ? `linear-gradient(90deg, ${t.accentSoft} 0%, transparent 85%)`
+          : 'transparent',
+        boxShadow: isActive
+          ? t.elevatedShadowSoft
+          : (isDark ? 'inset 0 1px 0 rgba(255,255,255,0.02)' : 'inset 0 1px 0 rgba(0,0,0,0.03)'),
         lineHeight: 1.4,
+        position: 'relative',
       }}>
+      {isActive && (
+        <span
+          aria-hidden="true"
+          style={{
+            position: 'absolute',
+            left: 0,
+            top: '20%',
+            height: '60%',
+            width: '3px',
+            borderRadius: '0 4px 4px 0',
+            background: t.accent,
+            opacity: 0.85,
+          }}
+        />
+      )}
       {doc.icon && <span style={{ flexShrink: 0, width: 15, height: 15, display: 'flex', alignItems: 'center', justifyContent: 'center', color: t.fgMuted }}><LucideIcon name={doc.icon} size={14} /></span>}
       <span style={{ minWidth: 0 }}>
         <span style={{ display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'normal', wordBreak: 'break-word', lineHeight: 1.35 }}>{doc.title}</span>
@@ -233,15 +253,35 @@ const HomePageLink: React.FC<{
       style={{
         display: 'flex', alignItems: 'center', gap: '0.5rem',
         padding: mobile ? '10px 14px' : '8px 10px',
-        borderRadius: '8px', fontSize: mobile ? '1rem' : '0.875rem',
+        borderRadius: '10px', fontSize: mobile ? '1rem' : '0.875rem',
         textDecoration: 'none',
-        border: `1px solid ${isActive ? t.elevatedBorder : 'transparent'}`,
+        border: `1px solid ${isActive ? t.elevatedBorder : t.border}`,
         color: isActive ? t.accent : t.fg, fontWeight: isActive ? 600 : 400,
-        background: isActive ? t.accentSoft : 'transparent',
-        boxShadow: isActive ? t.elevatedShadowSoft : 'none',
+        background: isActive
+          ? `linear-gradient(90deg, ${t.accentSoft} 0%, transparent 85%)`
+          : 'transparent',
+        boxShadow: isActive
+          ? t.elevatedShadowSoft
+          : (isDark ? 'inset 0 1px 0 rgba(255,255,255,0.02)' : 'inset 0 1px 0 rgba(0,0,0,0.03)'),
         lineHeight: 1.4,
+        position: 'relative',
       }}
     >
+      {isActive && (
+        <span
+          aria-hidden="true"
+          style={{
+            position: 'absolute',
+            left: 0,
+            top: '20%',
+            height: '60%',
+            width: '3px',
+            borderRadius: '0 4px 4px 0',
+            background: t.accent,
+            opacity: 0.85,
+          }}
+        />
+      )}
       <span style={{ flexShrink: 0, width: 15, height: 15, display: 'flex', alignItems: 'center', justifyContent: 'center', color: t.fgMuted }}>
         <Crown size={14} />
       </span>
@@ -258,9 +298,9 @@ const HomePageLink: React.FC<{
 
 function getCategoryNodeBackground(expanded: boolean, isDark: boolean): string {
   if (expanded) {
-    return isDark ? '#181818' : 'rgba(0,0,0,0.08)';
+    return isDark ? '#181818' : 'rgba(0,0,0,0.065)';
   }
-  return isDark ? '#0F0F0F' : '#deddd9';
+  return 'transparent';
 }
 
 const CategoryNode: React.FC<{

--- a/src/features/navigation/components/UnifiedSearchPanel.tsx
+++ b/src/features/navigation/components/UnifiedSearchPanel.tsx
@@ -42,6 +42,9 @@ interface DocMeta {
 
 type DateFilter = 'all' | 'new' | 'updated';
 type SortOrder  = 'date-desc' | 'date-asc';
+interface SiteConfig {
+  useLanding?: boolean;
+}
 
 const PAGE_SIZE      = 10;
 const LOAD_MORE_N    = 10;
@@ -80,7 +83,8 @@ function fmtDate(d: string): string {
 }
 
 function getDocUrl(doc: DocMeta): string {
-  return doc.slug === 'welcome' ? '/' : `/${doc.slug}/`;
+  if (doc.slug === '' || doc.slug === 'welcome') return '/';
+  return `/${doc.slug}/`;
 }
 
 function pluralResults(n: number): string {
@@ -419,6 +423,50 @@ function useSearchResults(docs: DocMeta[], opts: SearchOptions) {
   }, [debouncedQ, docs, filterCategory, filterSection, activeTags, dateFilter, sortOrder]);
 }
 
+function useSearchDocs(manifestDocs: DocMeta[]): DocMeta[] {
+  const [useLanding, setUseLanding] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    fetch('/data/site-config.json')
+      .then(res => {
+        if (!res.ok) return { useLanding: false } as SiteConfig;
+        return res.json() as Promise<SiteConfig>;
+      })
+      .then(cfg => {
+        if (!active) return;
+        setUseLanding(cfg.useLanding === true);
+      })
+      .catch(() => {
+        if (!active) return;
+        setUseLanding(false);
+      });
+
+    return () => { active = false; };
+  }, []);
+
+  return useMemo(() => {
+    const withoutWelcome = manifestDocs.filter(d => !(d.slug === '' || d.slug === 'welcome' || d.id === 'welcome'));
+    if (!useLanding) return manifestDocs;
+
+    const landingDoc: DocMeta = {
+      id: 'landing-home',
+      slug: '',
+      title: 'Главная страница',
+      description: 'Лендинг Opensophy: быстрый доступ к разделам, материалам и инструментам проекта.',
+      type: '',
+      navSlug: '',
+      navTitle: 'Главная',
+      icon: 'crown',
+      tags: ['landing', 'главная', 'opensophy'],
+      lang: 'ru',
+    };
+
+    return [landingDoc, ...withoutWelcome];
+  }, [manifestDocs, useLanding]);
+}
+
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 const UnifiedSearchPanel: React.FC<UnifiedSearchPanelProps> = ({ onClose }) => {
@@ -442,7 +490,7 @@ const UnifiedSearchPanel: React.FC<UnifiedSearchPanelProps> = ({ onClose }) => {
   const listRef    = useRef<HTMLDivElement>(null);
   const debouncedQ = useDebounce(query, 200);
 
-  const typedDocs = docs as DocMeta[];
+  const typedDocs = useSearchDocs(docs as DocMeta[]);
 
   const { allCategories, allTags, allSections, hasUpdatedDocs } = useSearchFilters(typedDocs);
 


### PR DESCRIPTION
### Motivation
- Make the navigation items visually clearer and more prominent (NoctaUI-like emphasis) while keeping the project's color tokens. 
- Fix search behavior when the site uses the landing-mode so users are routed to the live landing page instead of a blocked Markdown welcome page link. 

### Description
- Updated navigation visuals in `src/features/navigation/components/Navigation.tsx`: adjusted radii, border behavior, subtle gradient background for active items, left accent bar, improved box-shadow and transparent collapsed-category backgrounds for a cleaner tree look. 
- Fixed home URL handling and search result links in `src/features/navigation/components/UnifiedSearchPanel.tsx` by making empty slug (and `welcome`) resolve to `/`. 
- Added `useSearchDocs` inside `UnifiedSearchPanel.tsx` which reads `/data/site-config.json` and when `useLanding=true` hides `welcome.md` from results and injects a synthetic landing homepage result that points to `/`. 
- Kept all existing color tokens and project palette while adding the new visual highlights and maintained keyboard/selection behavior in search. 

### Testing
- Ran `npx eslint src/features/navigation/components/UnifiedSearchPanel.tsx src/features/navigation/components/Navigation.tsx` which completed for the modified files. 
- Ran `npm run lint` for the repository which surfaced pre-existing lint errors that are outside the scope of these changes (these failures are unrelated to this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef714e717883248a19d13898e867df)