### PR TITLE
Add under-layer glow to navigation panels and configurable landing doc in search

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -7,7 +7,7 @@
   <!-- Главная страница -->
   <url>
     <loc>https://opensophy.com/</loc>
-    <lastmod>2026-04-23</lastmod>
+    <lastmod>2026-04-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/src/features/navigation/components/Navigation.tsx
+++ b/src/features/navigation/components/Navigation.tsx
@@ -263,6 +263,12 @@ function getCategoryNodeBackground(expanded: boolean, isDark: boolean): string {
   return isDark ? '#0F0F0F' : '#deddd9';
 }
 
+function navUnderLayerGlow(isDark: boolean): string {
+  return isDark
+    ? 'inset 0 1px 0 rgba(255,255,255,0.05), 0 0 0 1px rgba(255,255,255,0.03), 0 12px 30px rgba(0,0,0,0.45)'
+    : 'inset 0 1px 0 rgba(255,255,255,0.7), 0 0 0 1px rgba(255,255,255,0.52), 0 10px 24px rgba(0,0,0,0.14)';
+}
+
 const CategoryNode: React.FC<{
   node: NavNode; path: string; expandedPaths: Set<string>;
   onToggle: (p: string) => void; isDark: boolean; currentDocSlug?: string;
@@ -985,7 +991,13 @@ const DesktopNav: React.FC<{
   return (
     <>
       {railVisible && (
-        <aside style={{ position: 'fixed', left: 0, top: 0, height: '100vh', width: RAIL_W, background: t.railBg, borderRight: `1px solid ${t.border}`, display: 'flex', flexDirection: 'column', alignItems: 'center', zIndex: 50, padding: '8px 0', gap: '2px' }}>
+        <aside style={{
+          position: 'fixed', left: 0, top: 0, height: '100vh', width: RAIL_W,
+          background: t.railBg, borderRight: `1px solid ${t.border}`,
+          display: 'flex', flexDirection: 'column', alignItems: 'center',
+          zIndex: 50, padding: '8px 0', gap: '2px',
+          boxShadow: navUnderLayerGlow(isDark),
+        }}>
           <div style={{ width: RAIL_W, height: 48, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
             <img src="/favicon.png" alt="hub" style={{ width: 28, height: 28, objectFit: 'contain' }} />
           </div>
@@ -1047,6 +1059,7 @@ const DesktopNav: React.FC<{
           background: t.panelBg, borderRight: panelOpen ? `1px solid ${t.border}` : 'none',
           display: 'flex', flexDirection: 'column', zIndex: 49, overflow: 'hidden',
           pointerEvents: panelOpen ? 'auto' : 'none', visibility: panelOpen ? 'visible' : 'hidden',
+          boxShadow: panelOpen ? navUnderLayerGlow(isDark) : 'none',
         }}>
           {panelOpen && (
             <>
@@ -1085,6 +1098,7 @@ const DesktopNav: React.FC<{
           position: 'fixed', right: 0, top: 0, width: TOC_PANEL_W, height: '100vh',
           borderLeft: `1px solid ${t.border}`, background: t.panelBg, zIndex: 48,
           display: 'flex', flexDirection: 'column',
+          boxShadow: navUnderLayerGlow(isDark),
         }}>
           <div style={{ borderBottom: `1px solid ${t.border}`, padding: '10px 12px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <span style={{ fontSize: '0.72rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', color: t.fgMuted }}>Оглавление</span>
@@ -1162,7 +1176,11 @@ const MobilePanel: React.FC<{
   const PANEL_TITLES: Record<string, string> = { nav: 'Навигация', toc: 'Оглавление', contacts: 'Контакты' };
 
   return createPortal(
-    <div style={{ position: 'fixed', inset: 0, zIndex: 62, background: t.panelFullBg, display: 'flex', flexDirection: 'column', overflow: 'hidden', animation: 'mobPanelIn 0.22s cubic-bezier(0.4,0,0.2,1)', paddingBottom: '60px' }}>
+    <div style={{
+      position: 'fixed', inset: 0, zIndex: 62, background: t.panelFullBg, display: 'flex',
+      flexDirection: 'column', overflow: 'hidden', animation: 'mobPanelIn 0.22s cubic-bezier(0.4,0,0.2,1)',
+      paddingBottom: '60px', boxShadow: navUnderLayerGlow(isDark),
+    }}>
       <style>{`@keyframes mobPanelIn{from{transform:translateY(100%)}to{transform:translateY(0)}}`}</style>
       <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '52px 20px 16px', borderBottom: `1px solid ${t.border}`, background: t.panelFullBg }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
@@ -1226,7 +1244,11 @@ const MobileNav: React.FC<{
         background: `linear-gradient(to bottom, transparent, ${t.mobBg})`,
       }} />
 
-      <nav style={{ position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 60, height: '60px', background: t.mobBg, borderTop: `1px solid ${t.border}`, display: 'flex', alignItems: 'stretch' }}>
+      <nav style={{
+        position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 60, height: '60px',
+        background: t.mobBg, borderTop: `1px solid ${t.border}`, display: 'flex', alignItems: 'stretch',
+        boxShadow: navUnderLayerGlow(isDark),
+      }}>
         <MobBtn label="Тема" icon={isDark ? <Sun size={22} /> : <Moon size={22} />} isDark={isDark} onClick={toggleTheme} isActive={false} />
         <MobBtn label="Поиск" icon={<Search size={22} />} isDark={isDark} onClick={() => { setSheet(null); setSearchOpen(true); }} isActive={false} />
 

--- a/src/features/navigation/components/UnifiedSearchPanel.tsx
+++ b/src/features/navigation/components/UnifiedSearchPanel.tsx
@@ -42,6 +42,9 @@ interface DocMeta {
 
 type DateFilter = 'all' | 'new' | 'updated';
 type SortOrder  = 'date-desc' | 'date-asc';
+interface SiteConfig {
+  useLanding?: boolean;
+}
 
 const PAGE_SIZE      = 10;
 const LOAD_MORE_N    = 10;
@@ -80,7 +83,8 @@ function fmtDate(d: string): string {
 }
 
 function getDocUrl(doc: DocMeta): string {
-  return doc.slug === 'welcome' ? '/' : `/${doc.slug}/`;
+  if (doc.slug === '' || doc.slug === 'welcome') return '/';
+  return `/${doc.slug}/`;
 }
 
 function pluralResults(n: number): string {
@@ -419,6 +423,50 @@ function useSearchResults(docs: DocMeta[], opts: SearchOptions) {
   }, [debouncedQ, docs, filterCategory, filterSection, activeTags, dateFilter, sortOrder]);
 }
 
+function useSearchDocs(manifestDocs: DocMeta[]): DocMeta[] {
+  const [useLanding, setUseLanding] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    fetch('/data/site-config.json')
+      .then(res => {
+        if (!res.ok) return { useLanding: false } as SiteConfig;
+        return res.json() as Promise<SiteConfig>;
+      })
+      .then(cfg => {
+        if (!active) return;
+        setUseLanding(cfg.useLanding === true);
+      })
+      .catch(() => {
+        if (!active) return;
+        setUseLanding(false);
+      });
+
+    return () => { active = false; };
+  }, []);
+
+  return useMemo(() => {
+    const withoutWelcome = manifestDocs.filter(d => !(d.slug === '' || d.slug === 'welcome' || d.id === 'welcome'));
+    if (!useLanding) return manifestDocs;
+
+    const landingDoc: DocMeta = {
+      id: 'landing-home',
+      slug: '',
+      title: 'Главная страница',
+      description: 'Лендинг Opensophy: быстрый доступ к разделам, материалам и инструментам проекта.',
+      type: '',
+      navSlug: '',
+      navTitle: 'Главная',
+      icon: 'crown',
+      tags: ['landing', 'главная', 'opensophy'],
+      lang: 'ru',
+    };
+
+    return [landingDoc, ...withoutWelcome];
+  }, [manifestDocs, useLanding]);
+}
+
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 const UnifiedSearchPanel: React.FC<UnifiedSearchPanelProps> = ({ onClose }) => {
@@ -442,7 +490,7 @@ const UnifiedSearchPanel: React.FC<UnifiedSearchPanelProps> = ({ onClose }) => {
   const listRef    = useRef<HTMLDivElement>(null);
   const debouncedQ = useDebounce(query, 200);
 
-  const typedDocs = docs as DocMeta[];
+  const typedDocs = useSearchDocs(docs as DocMeta[]);
 
   const { allCategories, allTags, allSections, hasUpdatedDocs } = useSearchFilters(typedDocs);
 


### PR DESCRIPTION
### Motivation
- Provide a subtle under-layer glow / shadow around navigation rails, panels and mobile sheets for better visual separation. 
- Make the unified search results respect a site configuration that can expose a dedicated landing page item and normalize welcome/empty slugs to the root URL.

### Description
- Introduced `navUnderLayerGlow(isDark: boolean)` utility and applied it as `boxShadow` to the left rail, collapsible panel, TOC sidebar, mobile panel, and mobile nav bar, using dark/light variants.
- Adjusted `getDocUrl` to treat an empty slug or `welcome` as the site root (`'/'`).
- Added `SiteConfig` interface and a new `useSearchDocs` hook that fetches `/data/site-config.json` and, when `useLanding` is true, prepends a synthesized landing doc (`id: 'landing-home'`) while filtering out legacy `welcome`/empty entries from the manifest.
- Wired the unified search to use `useSearchDocs` instead of the raw manifest and preserved existing scoring, filtering and pagination logic.

### Testing
- Ran a full build/typecheck with `yarn build` and the TypeScript build succeeded. 
- Executed the test suite with `yarn test` and all automated tests passed. 
- Verified linting with `yarn lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef714e717883248a19d13898e867df)