### PR TITLE
Add configurable DotWave hero background and site-config integration

### DIFF
--- a/public/data/site-config.json
+++ b/public/data/site-config.json
@@ -1,3 +1,4 @@
 {
-  "useLanding": true
+  "useLanding": true,
+  "showDotWaveBackground": true
 }

--- a/public/data/site-config.json
+++ b/public/data/site-config.json
@@ -1,4 +1,4 @@
 {
   "useLanding": true,
-  "showDotWaveBackground": true
+  "showDotWaveBackground": false
 }

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -7,7 +7,7 @@
   <!-- Главная страница -->
   <url>
     <loc>https://opensophy.com/</loc>
-    <lastmod>2026-04-23</lastmod>
+    <lastmod>2026-04-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/scripts/devBridge.mjs
+++ b/scripts/devBridge.mjs
@@ -236,13 +236,16 @@ async function handleRenderPreview({ markdown }) {
 async function handleReadSiteConfig() {
   try {
     if (!fs.existsSync(SITE_CONFIG_PATH)) {
-      return { config: { useLanding: false } };
+      return { config: { useLanding: false, showDotWaveBackground: true } };
     }
     const raw = await fs.promises.readFile(SITE_CONFIG_PATH, 'utf-8');
     const config = JSON.parse(raw);
+    if (typeof config.showDotWaveBackground !== 'boolean') {
+      config.showDotWaveBackground = true;
+    }
     return { config };
   } catch {
-    return { config: { useLanding: false } };
+    return { config: { useLanding: false, showDotWaveBackground: true } };
   }
 }
 

--- a/src/features/dev-panel/panels/SitePanel.tsx
+++ b/src/features/dev-panel/panels/SitePanel.tsx
@@ -8,7 +8,7 @@ import type { SiteConfig } from '../useDevBridge';
 export default function SitePanel() {
   const t = useContext(ThemeTokensContext);
 
-  const [config, setConfig]   = useState<SiteConfig>({ useLanding: false });
+  const [config, setConfig]   = useState<SiteConfig>({ useLanding: false, showDotWaveBackground: true });
   const [loading, setLoading] = useState(true);
   const [saving, setSaving]   = useState(false);
   const [error, setError]     = useState('');
@@ -21,7 +21,10 @@ export default function SitePanel() {
     setError('');
     try {
       const { config: cfg } = await bridge.readSiteConfig();
-      setConfig(cfg);
+      setConfig({
+        useLanding: cfg.useLanding === true,
+        showDotWaveBackground: cfg.showDotWaveBackground !== false,
+      });
     } catch (e: unknown) {
       setError((e as Error).message);
     } finally {
@@ -40,6 +43,23 @@ export default function SitePanel() {
     try {
       await bridge.writeSiteConfig(next);
       toast.success(value ? 'Лендинг включён' : 'Welcome.md включён');
+    } catch (e: unknown) {
+      setError((e as Error).message);
+      setConfig(prevConfig.current);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggleDotWave = async (value: boolean) => {
+    const next = { ...config, showDotWaveBackground: value };
+    prevConfig.current = config;
+    setConfig(next);
+    setSaving(true);
+    setError('');
+    try {
+      await bridge.writeSiteConfig(next);
+      toast.success(value ? 'DotWave фон включён' : 'DotWave фон отключён');
     } catch (e: unknown) {
       setError((e as Error).message);
       setConfig(prevConfig.current);
@@ -184,6 +204,35 @@ export default function SitePanel() {
       {/* Разделитель */}
       <div style={{ height: 1, background: t.border, margin: '8px 0 12px' }} />
 
+      {/* Настройки hero-фона документации */}
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        marginBottom: 10, padding: '10px 12px',
+        borderRadius: 7, border: `1px solid ${t.border}`, background: t.surface,
+      }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <span style={{ fontSize: 11, color: t.fgMuted, fontWeight: 600 }}>DotWave фон в шапке документа</span>
+          <span style={{ fontSize: 10, color: t.fgSub }}>Если выключить, фон будет как у навигации.</span>
+        </div>
+        <button
+          disabled={saving}
+          onClick={() => handleToggleDotWave(!(config.showDotWaveBackground ?? true))}
+          style={{
+            border: `1px solid ${t.border}`,
+            background: (config.showDotWaveBackground ?? true) ? t.accentSoft : 'transparent',
+            color: t.fgMuted,
+            borderRadius: 6,
+            padding: '5px 9px',
+            fontSize: 10,
+            fontFamily: t.mono,
+            cursor: saving ? 'not-allowed' : 'pointer',
+            opacity: saving ? 0.7 : 1,
+          }}
+        >
+          {(config.showDotWaveBackground ?? true) ? 'ВКЛ' : 'ВЫКЛ'}
+        </button>
+      </div>
+
       {/* Текущее состояние */}
       <div style={{
         fontSize: 10, color: t.fgSub,
@@ -191,7 +240,7 @@ export default function SitePanel() {
       }}>
         <span>
           Сейчас: <strong style={{ color: t.fgMuted }}>
-            {config.useLanding ? 'Лендинг' : 'Welcome.md'}
+            {config.useLanding ? 'Лендинг' : 'Welcome.md'} · DotWave: {(config.showDotWaveBackground ?? true) ? 'вкл' : 'выкл'}
           </strong>
         </span>
         <button

--- a/src/features/dev-panel/useDevBridge.ts
+++ b/src/features/dev-panel/useDevBridge.ts
@@ -141,6 +141,7 @@ export function useDevBridge() {
 
 export interface SiteConfig {
   useLanding: boolean;
+  showDotWaveBackground?: boolean;
 }
 
 // ─── Typed bridge API ──────────────────────────────────────────────────────────

--- a/src/features/docs/components/DocContent.tsx
+++ b/src/features/docs/components/DocContent.tsx
@@ -74,16 +74,19 @@ interface DocHeroProps {
   isDark: boolean;
   readTime: number;
   liveFM?: LiveFM | null;
+  showDotWaveBackground: boolean;
 }
 
-const DocHero: React.FC<DocHeroProps> = ({ doc, isDark, readTime, liveFM }) => {
+const DocHero: React.FC<DocHeroProps> = ({ doc, isDark, readTime, liveFM, showDotWaveBackground }) => {
   const title       = liveFM?.title?.trim()       || doc.title;
   const description = liveFM?.description?.trim() || doc.description;
   const author      = liveFM?.author?.trim()       || doc.author;
   const date        = liveFM?.date?.trim()         || doc.date;
   const updated     = liveFM?.updated?.trim()      || doc.updated;
 
-  const heroBg      = isDark ? '#0a0a0a' : '#E8E7E3';
+  const heroBg      = showDotWaveBackground
+    ? (isDark ? '#0a0a0a' : '#E8E7E3')
+    : (isDark ? '#0F0F0F' : '#E0DFDb');
   const borderColor = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
   const metaClr     = isDark ? 'rgba(255,255,255,0.45)' : 'rgba(0,0,0,0.75)';
   const badgeBg     = isDark ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.06)';
@@ -98,7 +101,7 @@ const DocHero: React.FC<DocHeroProps> = ({ doc, isDark, readTime, liveFM }) => {
   return (
     <div style={{ background: heroBg, borderBottom: `1px solid ${borderColor}`, padding: '3rem 2rem 2.5rem', position: 'relative' }}>
       <div style={{ position: 'absolute', inset: 0, overflow: 'hidden', pointerEvents: 'none', contain: 'strict' }}>
-        <DotWaveBackground isDark={isDark} />
+        {showDotWaveBackground && <DotWaveBackground isDark={isDark} />}
       </div>
       <div style={{ position: 'relative', zIndex: 1 }}>
         {doc.typename?.trim() && (
@@ -169,6 +172,7 @@ const DocHero: React.FC<DocHeroProps> = ({ doc, isDark, readTime, liveFM }) => {
 const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
   const { isDark } = useTheme();
   const [fullscreenTableHtml, setFullscreenTableHtml] = useState<string | null>(null);
+  const [showDotWaveBackground, setShowDotWaveBackground] = useState(true);
 
   const [isDesktop, setIsDesktop] = useState(false);
   const [navLeft, setNavLeft]     = useState('0px');
@@ -213,6 +217,21 @@ const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
     observer.observe(document.documentElement, { attributes: true, attributeFilter: ['style'] });
     return () => observer.disconnect();
   }, [isDesktop]);
+
+  useEffect(() => {
+    let mounted = true;
+    fetch('/data/site-config.json')
+      .then(r => (r.ok ? r.json() : { showDotWaveBackground: true }))
+      .then(cfg => {
+        if (!mounted) return;
+        setShowDotWaveBackground(cfg.showDotWaveBackground !== false);
+      })
+      .catch(() => {
+        if (!mounted) return;
+        setShowDotWaveBackground(true);
+      });
+    return () => { mounted = false; };
+  }, []);
 
   // ── Live preview via BroadcastChannel ────────────────────────────────────
   const [liveHtml, setLiveHtml] = useState<string | null>(null);
@@ -285,7 +304,13 @@ const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
           transition:   'none',
         }}
       >
-        <DocHero doc={doc} isDark={isDark} readTime={readTime} liveFM={liveFM} />
+        <DocHero
+          doc={doc}
+          isDark={isDark}
+          readTime={readTime}
+          liveFM={liveFM}
+          showDotWaveBackground={showDotWaveBackground}
+        />
 
         <article style={{
           padding: '2rem 2rem 3rem',

--- a/src/features/navigation/components/Navigation.tsx
+++ b/src/features/navigation/components/Navigation.tsx
@@ -679,7 +679,7 @@ const NavPanelContent: React.FC<{
               background: t.dropdownBg,
               zIndex: 100,
               overflow: 'hidden',
-              boxShadow: t.dropdownShadow,
+              boxShadow: 'none',
             }}>
               <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', padding: '8px' }}>
                 <SectionDropdown sections={sections} activeNavSlug={activeNavSlug} mobile={!!mobile} isDark={isDark} onSelect={handleSectionSelect} />
@@ -902,7 +902,7 @@ const PanelResizeToggle: React.FC<{
           background: getPanelToggleBackground(hov, isDark),
           color: hov ? t.fg : t.fgMuted, cursor: 'pointer', padding: 0,
           display: 'flex', alignItems: 'center', justifyContent: 'center',
-          boxShadow: hov ? t.elevatedShadowSoft : 'none',
+          boxShadow: 'none',
         }}>
         {panelOpen ? <ChevronLeft size={11} strokeWidth={2.5} /> : <ChevronRight size={11} strokeWidth={2.5} />}
       </button>
@@ -985,7 +985,12 @@ const DesktopNav: React.FC<{
   return (
     <>
       {railVisible && (
-        <aside style={{ position: 'fixed', left: 0, top: 0, height: '100vh', width: RAIL_W, background: t.railBg, borderRight: `1px solid ${t.border}`, display: 'flex', flexDirection: 'column', alignItems: 'center', zIndex: 50, padding: '8px 0', gap: '2px' }}>
+        <aside style={{
+          position: 'fixed', left: 0, top: 0, height: '100vh', width: RAIL_W,
+          background: t.railBg, borderRight: `1px solid ${t.border}`,
+          display: 'flex', flexDirection: 'column', alignItems: 'center',
+          zIndex: 50, padding: '8px 0', gap: '2px',
+        }}>
           <div style={{ width: RAIL_W, height: 48, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
             <img src="/favicon.png" alt="hub" style={{ width: 28, height: 28, objectFit: 'contain' }} />
           </div>
@@ -1007,7 +1012,7 @@ const DesktopNav: React.FC<{
                 {readingModeMenuOpen && (
                   <div style={{
                     position: 'absolute', left: '100%', top: 0, marginLeft: '8px', width: '190px', padding: '8px',
-                    borderRadius: '10px', border: `1px solid ${t.border}`, background: t.panelBg, boxShadow: t.elevatedShadow, zIndex: 70,
+                    borderRadius: '10px', border: `1px solid ${t.border}`, background: t.panelBg, boxShadow: 'none', zIndex: 70,
                   }}>
                     <button onClick={() => { setReadingMode('standard'); setReadingModeMenuOpen(false); }}
                       style={{ width: '100%', textAlign: 'left', border: 'none', borderRadius: '8px', padding: '8px 10px', cursor: 'pointer', background: readingMode === 'standard' ? t.accentSoft : 'transparent', color: t.fg, fontSize: '0.8rem' }}>
@@ -1074,6 +1079,25 @@ const DesktopNav: React.FC<{
           )}
         </aside>
       )}
+      {railVisible && panelOpen && (
+        <div
+          aria-hidden="true"
+          style={{
+            position: 'fixed',
+            left: RAIL_W + panelWidth - 1,
+            top: 0,
+            width: 20,
+            height: '100vh',
+            zIndex: 48,
+            pointerEvents: 'none',
+            background: isDark
+              ? 'linear-gradient(to right, rgba(15,15,15,0.56), rgba(15,15,15,0.12), transparent)'
+              : 'linear-gradient(to right, rgba(224,223,219,0.7), rgba(224,223,219,0.2), transparent)',
+            backdropFilter: 'blur(8px)',
+            WebkitBackdropFilter: 'blur(8px)',
+          }}
+        />
+      )}
 
       {railVisible && !isStandardMode && (
         <PanelResizeToggle isDark={isDark} panelOpen={panelOpen} panelWidth={panelWidth} onResizeMouseDown={onResizeMouseDown}
@@ -1110,6 +1134,25 @@ const DesktopNav: React.FC<{
             <TocPanelContent toc={toc} activeId={activeId} isDark={isDark} />
           </div>
         </aside>
+      )}
+      {isStandardMode && standardTocVisible && (
+        <div
+          aria-hidden="true"
+          style={{
+            position: 'fixed',
+            right: TOC_PANEL_W - 1,
+            top: 0,
+            width: 20,
+            height: '100vh',
+            zIndex: 47,
+            pointerEvents: 'none',
+            background: isDark
+              ? 'linear-gradient(to left, rgba(15,15,15,0.56), rgba(15,15,15,0.12), transparent)'
+              : 'linear-gradient(to left, rgba(224,223,219,0.7), rgba(224,223,219,0.2), transparent)',
+            backdropFilter: 'blur(8px)',
+            WebkitBackdropFilter: 'blur(8px)',
+          }}
+        />
       )}
 
       {isStandardMode && !standardTocVisible && (
@@ -1162,7 +1205,11 @@ const MobilePanel: React.FC<{
   const PANEL_TITLES: Record<string, string> = { nav: 'Навигация', toc: 'Оглавление', contacts: 'Контакты' };
 
   return createPortal(
-    <div style={{ position: 'fixed', inset: 0, zIndex: 62, background: t.panelFullBg, display: 'flex', flexDirection: 'column', overflow: 'hidden', animation: 'mobPanelIn 0.22s cubic-bezier(0.4,0,0.2,1)', paddingBottom: '60px' }}>
+    <div style={{
+      position: 'fixed', inset: 0, zIndex: 62, background: t.panelFullBg, display: 'flex',
+      flexDirection: 'column', overflow: 'hidden', animation: 'mobPanelIn 0.22s cubic-bezier(0.4,0,0.2,1)',
+      paddingBottom: '60px',
+    }}>
       <style>{`@keyframes mobPanelIn{from{transform:translateY(100%)}to{transform:translateY(0)}}`}</style>
       <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '52px 20px 16px', borderBottom: `1px solid ${t.border}`, background: t.panelFullBg }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
@@ -1226,7 +1273,10 @@ const MobileNav: React.FC<{
         background: `linear-gradient(to bottom, transparent, ${t.mobBg})`,
       }} />
 
-      <nav style={{ position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 60, height: '60px', background: t.mobBg, borderTop: `1px solid ${t.border}`, display: 'flex', alignItems: 'stretch' }}>
+      <nav style={{
+        position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 60, height: '60px',
+        background: t.mobBg, borderTop: `1px solid ${t.border}`, display: 'flex', alignItems: 'stretch',
+      }}>
         <MobBtn label="Тема" icon={isDark ? <Sun size={22} /> : <Moon size={22} />} isDark={isDark} onClick={toggleTheme} isActive={false} />
         <MobBtn label="Поиск" icon={<Search size={22} />} isDark={isDark} onClick={() => { setSheet(null); setSearchOpen(true); }} isActive={false} />
 

--- a/src/features/navigation/components/UnifiedSearchPanel.tsx
+++ b/src/features/navigation/components/UnifiedSearchPanel.tsx
@@ -42,6 +42,9 @@ interface DocMeta {
 
 type DateFilter = 'all' | 'new' | 'updated';
 type SortOrder  = 'date-desc' | 'date-asc';
+interface SiteConfig {
+  useLanding?: boolean;
+}
 
 const PAGE_SIZE      = 10;
 const LOAD_MORE_N    = 10;
@@ -80,7 +83,8 @@ function fmtDate(d: string): string {
 }
 
 function getDocUrl(doc: DocMeta): string {
-  return doc.slug === 'welcome' ? '/' : `/${doc.slug}/`;
+  if (doc.slug === '' || doc.slug === 'welcome') return '/';
+  return `/${doc.slug}/`;
 }
 
 function pluralResults(n: number): string {
@@ -419,6 +423,50 @@ function useSearchResults(docs: DocMeta[], opts: SearchOptions) {
   }, [debouncedQ, docs, filterCategory, filterSection, activeTags, dateFilter, sortOrder]);
 }
 
+function useSearchDocs(manifestDocs: DocMeta[]): DocMeta[] {
+  const [useLanding, setUseLanding] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    fetch('/data/site-config.json')
+      .then(res => {
+        if (!res.ok) return { useLanding: false } as SiteConfig;
+        return res.json() as Promise<SiteConfig>;
+      })
+      .then(cfg => {
+        if (!active) return;
+        setUseLanding(cfg.useLanding === true);
+      })
+      .catch(() => {
+        if (!active) return;
+        setUseLanding(false);
+      });
+
+    return () => { active = false; };
+  }, []);
+
+  return useMemo(() => {
+    const withoutWelcome = manifestDocs.filter(d => !(d.slug === '' || d.slug === 'welcome' || d.id === 'welcome'));
+    if (!useLanding) return manifestDocs;
+
+    const landingDoc: DocMeta = {
+      id: 'landing-home',
+      slug: '',
+      title: 'Главная страница',
+      description: 'Лендинг Opensophy: быстрый доступ к разделам, материалам и инструментам проекта.',
+      type: '',
+      navSlug: '',
+      navTitle: 'Главная',
+      icon: 'crown',
+      tags: ['landing', 'главная', 'opensophy'],
+      lang: 'ru',
+    };
+
+    return [landingDoc, ...withoutWelcome];
+  }, [manifestDocs, useLanding]);
+}
+
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 const UnifiedSearchPanel: React.FC<UnifiedSearchPanelProps> = ({ onClose }) => {
@@ -442,7 +490,7 @@ const UnifiedSearchPanel: React.FC<UnifiedSearchPanelProps> = ({ onClose }) => {
   const listRef    = useRef<HTMLDivElement>(null);
   const debouncedQ = useDebounce(query, 200);
 
-  const typedDocs = docs as DocMeta[];
+  const typedDocs = useSearchDocs(docs as DocMeta[]);
 
   const { allCategories, allTags, allSections, hasUpdatedDocs } = useSearchFilters(typedDocs);
 


### PR DESCRIPTION
### Motivation
- Introduce a toggleable DotWave background for documentation hero and expose it via the site configuration so teams can enable/disable the visual without rebuilding.
- Make the dev panel able to read/write the new setting and keep backward compatibility for environments missing the key.
- Ensure search and routing continue to treat the landing/welcome page correctly when `useLanding` is enabled.

### Description
- Add `showDotWaveBackground` boolean to `public/data/site-config.json` and treat `true` as the default.
- Extend the dev bridge handler `handleReadSiteConfig` to return `showDotWaveBackground: true` by default and validate the field when reading the config file, and keep write support via `handleWriteSiteConfig`.
- Update `SitePanel` UI to surface a toggle for the DotWave hero background and wire it to `bridge.writeSiteConfig`, including optimistic UI updates and error rollback logic via `prevConfig`.
- Add `showDotWaveBackground` to the `SiteConfig` type in `useDevBridge.ts` and expose it through the typed bridge API.
- Make `DocContent` consume `showDotWaveBackground` to conditionally render `DotWaveBackground` and to adapt hero background colors; add client-side fetch of `/data/site-config.json` to set the runtime flag in `DocContentMain`.
- Improve unified search behavior by introducing `useSearchDocs` which fetches `useLanding` from `/data/site-config.json` and injects a synthetic landing doc when `useLanding` is enabled; also adjust `getDocUrl` to return `/` for empty or `welcome` slugs.
- Several UI polish changes in navigation components: removed/adjusted some `boxShadow` usages, added subtle gradient overlays beside panels, and minor layout/style refactors for consistency.

### Testing
- Performed a TypeScript type-check using `tsc --noEmit`, which completed successfully.
- Performed a production build via `pnpm build` which completed successfully and emitted the updated assets.
- Ran a local dev smoke test by starting the dev server and exercising the Dev Panel toggle and docs pages; no runtime errors were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef714e717883248a19d13898e867df)