### PR TITLE
Add optional DotWave hero background, dev panel toggle, and landing-aware search

### DIFF
--- a/public/data/site-config.json
+++ b/public/data/site-config.json
@@ -1,3 +1,4 @@
 {
-  "useLanding": true
+  "useLanding": true,
+  "showDotWaveBackground": true
 }

--- a/scripts/devBridge.mjs
+++ b/scripts/devBridge.mjs
@@ -236,13 +236,16 @@ async function handleRenderPreview({ markdown }) {
 async function handleReadSiteConfig() {
   try {
     if (!fs.existsSync(SITE_CONFIG_PATH)) {
-      return { config: { useLanding: false } };
+      return { config: { useLanding: false, showDotWaveBackground: true } };
     }
     const raw = await fs.promises.readFile(SITE_CONFIG_PATH, 'utf-8');
     const config = JSON.parse(raw);
+    if (typeof config.showDotWaveBackground !== 'boolean') {
+      config.showDotWaveBackground = true;
+    }
     return { config };
   } catch {
-    return { config: { useLanding: false } };
+    return { config: { useLanding: false, showDotWaveBackground: true } };
   }
 }
 

--- a/src/features/dev-panel/panels/SitePanel.tsx
+++ b/src/features/dev-panel/panels/SitePanel.tsx
@@ -8,7 +8,7 @@ import type { SiteConfig } from '../useDevBridge';
 export default function SitePanel() {
   const t = useContext(ThemeTokensContext);
 
-  const [config, setConfig]   = useState<SiteConfig>({ useLanding: false });
+  const [config, setConfig]   = useState<SiteConfig>({ useLanding: false, showDotWaveBackground: true });
   const [loading, setLoading] = useState(true);
   const [saving, setSaving]   = useState(false);
   const [error, setError]     = useState('');
@@ -21,7 +21,10 @@ export default function SitePanel() {
     setError('');
     try {
       const { config: cfg } = await bridge.readSiteConfig();
-      setConfig(cfg);
+      setConfig({
+        useLanding: cfg.useLanding === true,
+        showDotWaveBackground: cfg.showDotWaveBackground !== false,
+      });
     } catch (e: unknown) {
       setError((e as Error).message);
     } finally {
@@ -40,6 +43,23 @@ export default function SitePanel() {
     try {
       await bridge.writeSiteConfig(next);
       toast.success(value ? 'Лендинг включён' : 'Welcome.md включён');
+    } catch (e: unknown) {
+      setError((e as Error).message);
+      setConfig(prevConfig.current);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggleDotWave = async (value: boolean) => {
+    const next = { ...config, showDotWaveBackground: value };
+    prevConfig.current = config;
+    setConfig(next);
+    setSaving(true);
+    setError('');
+    try {
+      await bridge.writeSiteConfig(next);
+      toast.success(value ? 'DotWave фон включён' : 'DotWave фон отключён');
     } catch (e: unknown) {
       setError((e as Error).message);
       setConfig(prevConfig.current);
@@ -184,6 +204,35 @@ export default function SitePanel() {
       {/* Разделитель */}
       <div style={{ height: 1, background: t.border, margin: '8px 0 12px' }} />
 
+      {/* Настройки hero-фона документации */}
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        marginBottom: 10, padding: '10px 12px',
+        borderRadius: 7, border: `1px solid ${t.border}`, background: t.surface,
+      }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <span style={{ fontSize: 11, color: t.fgMuted, fontWeight: 600 }}>DotWave фон в шапке документа</span>
+          <span style={{ fontSize: 10, color: t.fgSub }}>Если выключить, фон будет как у навигации.</span>
+        </div>
+        <button
+          disabled={saving}
+          onClick={() => handleToggleDotWave(!(config.showDotWaveBackground ?? true))}
+          style={{
+            border: `1px solid ${t.border}`,
+            background: (config.showDotWaveBackground ?? true) ? t.accentSoft : 'transparent',
+            color: t.fgMuted,
+            borderRadius: 6,
+            padding: '5px 9px',
+            fontSize: 10,
+            fontFamily: t.mono,
+            cursor: saving ? 'not-allowed' : 'pointer',
+            opacity: saving ? 0.7 : 1,
+          }}
+        >
+          {(config.showDotWaveBackground ?? true) ? 'ВКЛ' : 'ВЫКЛ'}
+        </button>
+      </div>
+
       {/* Текущее состояние */}
       <div style={{
         fontSize: 10, color: t.fgSub,
@@ -191,7 +240,7 @@ export default function SitePanel() {
       }}>
         <span>
           Сейчас: <strong style={{ color: t.fgMuted }}>
-            {config.useLanding ? 'Лендинг' : 'Welcome.md'}
+            {config.useLanding ? 'Лендинг' : 'Welcome.md'} · DotWave: {(config.showDotWaveBackground ?? true) ? 'вкл' : 'выкл'}
           </strong>
         </span>
         <button

--- a/src/features/dev-panel/useDevBridge.ts
+++ b/src/features/dev-panel/useDevBridge.ts
@@ -141,6 +141,7 @@ export function useDevBridge() {
 
 export interface SiteConfig {
   useLanding: boolean;
+  showDotWaveBackground?: boolean;
 }
 
 // ─── Typed bridge API ──────────────────────────────────────────────────────────

--- a/src/features/docs/components/DocContent.tsx
+++ b/src/features/docs/components/DocContent.tsx
@@ -74,18 +74,21 @@ interface DocHeroProps {
   isDark: boolean;
   readTime: number;
   liveFM?: LiveFM | null;
+  showDotWaveBackground: boolean;
 }
 
-const DocHero: React.FC<DocHeroProps> = ({ doc, isDark, readTime, liveFM }) => {
+const DocHero: React.FC<DocHeroProps> = ({ doc, isDark, readTime, liveFM, showDotWaveBackground }) => {
   const title       = liveFM?.title?.trim()       || doc.title;
   const description = liveFM?.description?.trim() || doc.description;
   const author      = liveFM?.author?.trim()       || doc.author;
   const date        = liveFM?.date?.trim()         || doc.date;
   const updated     = liveFM?.updated?.trim()      || doc.updated;
 
-  const heroBg      = isDark ? '#0a0a0a' : '#E8E7E3';
+  const heroBg      = showDotWaveBackground
+    ? (isDark ? '#0a0a0a' : '#E8E7E3')
+    : (isDark ? '#0F0F0F' : '#E0DFDb');
   const borderColor = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
-  const metaClr     = isDark ? 'rgba(255,255,255,0.45)' : 'rgba(0,0,0,0.75)';
+  const metaClr     = isDark ? '#ffffff' : '#000000';
   const badgeBg     = isDark ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.06)';
   const badgeBdr    = isDark ? 'rgba(255,255,255,0.1)'  : 'rgba(0,0,0,0.1)';
   const textPrimary = isDark ? '#ffffff' : '#000000';
@@ -98,7 +101,7 @@ const DocHero: React.FC<DocHeroProps> = ({ doc, isDark, readTime, liveFM }) => {
   return (
     <div style={{ background: heroBg, borderBottom: `1px solid ${borderColor}`, padding: '3rem 2rem 2.5rem', position: 'relative' }}>
       <div style={{ position: 'absolute', inset: 0, overflow: 'hidden', pointerEvents: 'none', contain: 'strict' }}>
-        <DotWaveBackground isDark={isDark} />
+        {showDotWaveBackground && <DotWaveBackground isDark={isDark} />}
       </div>
       <div style={{ position: 'relative', zIndex: 1 }}>
         {doc.typename?.trim() && (
@@ -169,6 +172,7 @@ const DocHero: React.FC<DocHeroProps> = ({ doc, isDark, readTime, liveFM }) => {
 const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
   const { isDark } = useTheme();
   const [fullscreenTableHtml, setFullscreenTableHtml] = useState<string | null>(null);
+  const [showDotWaveBackground, setShowDotWaveBackground] = useState(true);
 
   const [isDesktop, setIsDesktop] = useState(false);
   const [navLeft, setNavLeft]     = useState('0px');
@@ -213,6 +217,21 @@ const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
     observer.observe(document.documentElement, { attributes: true, attributeFilter: ['style'] });
     return () => observer.disconnect();
   }, [isDesktop]);
+
+  useEffect(() => {
+    let mounted = true;
+    fetch('/data/site-config.json')
+      .then(r => (r.ok ? r.json() : { showDotWaveBackground: true }))
+      .then(cfg => {
+        if (!mounted) return;
+        setShowDotWaveBackground(cfg.showDotWaveBackground !== false);
+      })
+      .catch(() => {
+        if (!mounted) return;
+        setShowDotWaveBackground(true);
+      });
+    return () => { mounted = false; };
+  }, []);
 
   // ── Live preview via BroadcastChannel ────────────────────────────────────
   const [liveHtml, setLiveHtml] = useState<string | null>(null);
@@ -265,6 +284,11 @@ const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
     () => ({ onTableClick: (html: string) => setFullscreenTableHtml(html), isDark }),
     [isDark]
   );
+  const cardBg = isDark ? 'rgba(10,10,11,0.84)' : 'rgba(236,235,231,0.88)';
+  const cardBorder = isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.14)';
+  const cardShadow = isDark
+    ? '0 24px 80px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.05)'
+    : '0 18px 60px rgba(0,0,0,0.13), inset 0 1px 0 rgba(255,255,255,0.85)';
 
   return (
     <div style={{ minHeight: '100vh' }}>
@@ -282,25 +306,45 @@ const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
           marginLeft:   isDesktop ? navLeft : '0',
           marginRight:  isDesktop ? docRight : '0',
           marginBottom: isDesktop ? '0' : '3.5rem',
+          padding: isDesktop ? '0 12px 18px' : '0 8px 18px',
           transition:   'none',
         }}
       >
-        <DocHero doc={doc} isDark={isDark} readTime={readTime} liveFM={liveFM} />
+        <DocHero
+          doc={doc}
+          isDark={isDark}
+          readTime={readTime}
+          liveFM={liveFM}
+          showDotWaveBackground={showDotWaveBackground}
+        />
 
-        <article style={{
-          padding: '2rem 2rem 3rem',
-          borderLeft: showLeftBorder ? `1px solid ${isDark ? 'rgba(255,255,255,0.16)' : 'rgba(0,0,0,0.2)'}` : 'none',
-          borderRight: showRightBorder ? `1px solid ${isDark ? 'rgba(255,255,255,0.16)' : 'rgba(0,0,0,0.2)'}` : 'none',
+        <div style={{
+          marginTop: isDesktop ? '-24px' : '-14px',
+          position: 'relative',
+          zIndex: 2,
+          borderRadius: isDesktop ? '18px' : '14px',
+          border: `1px solid ${cardBorder}`,
+          background: cardBg,
+          boxShadow: cardShadow,
+          backdropFilter: 'blur(14px)',
+          WebkitBackdropFilter: 'blur(14px)',
+          overflow: 'hidden',
         }}>
-          <TableContext.Provider value={tableCtx}>
-            <div
-              data-article-content
-              className={`prose max-w-none w-full overflow-x-auto ${isDark ? 'text-white' : 'text-black'}`}
-            >
-              {contentNodes}
-            </div>
-          </TableContext.Provider>
-        </article>
+          <article style={{
+            padding: '2rem 2rem 3rem',
+            borderLeft: showLeftBorder ? `1px solid ${isDark ? 'rgba(255,255,255,0.16)' : 'rgba(0,0,0,0.2)'}` : 'none',
+            borderRight: showRightBorder ? `1px solid ${isDark ? 'rgba(255,255,255,0.16)' : 'rgba(0,0,0,0.2)'}` : 'none',
+          }}>
+            <TableContext.Provider value={tableCtx}>
+              <div
+                data-article-content
+                className={`prose max-w-none w-full overflow-x-auto ${isDark ? 'text-white' : 'text-black'}`}
+              >
+                {contentNodes}
+              </div>
+            </TableContext.Provider>
+          </article>
+        </div>
       </main>
 
       <AnimatePresence>

--- a/src/features/navigation/components/Navigation.tsx
+++ b/src/features/navigation/components/Navigation.tsx
@@ -679,7 +679,7 @@ const NavPanelContent: React.FC<{
               background: t.dropdownBg,
               zIndex: 100,
               overflow: 'hidden',
-              boxShadow: t.dropdownShadow,
+              boxShadow: 'none',
             }}>
               <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', padding: '8px' }}>
                 <SectionDropdown sections={sections} activeNavSlug={activeNavSlug} mobile={!!mobile} isDark={isDark} onSelect={handleSectionSelect} />
@@ -902,7 +902,7 @@ const PanelResizeToggle: React.FC<{
           background: getPanelToggleBackground(hov, isDark),
           color: hov ? t.fg : t.fgMuted, cursor: 'pointer', padding: 0,
           display: 'flex', alignItems: 'center', justifyContent: 'center',
-          boxShadow: hov ? t.elevatedShadowSoft : 'none',
+          boxShadow: 'none',
         }}>
         {panelOpen ? <ChevronLeft size={11} strokeWidth={2.5} /> : <ChevronRight size={11} strokeWidth={2.5} />}
       </button>
@@ -985,7 +985,12 @@ const DesktopNav: React.FC<{
   return (
     <>
       {railVisible && (
-        <aside style={{ position: 'fixed', left: 0, top: 0, height: '100vh', width: RAIL_W, background: t.railBg, borderRight: `1px solid ${t.border}`, display: 'flex', flexDirection: 'column', alignItems: 'center', zIndex: 50, padding: '8px 0', gap: '2px' }}>
+        <aside style={{
+          position: 'fixed', left: 0, top: 0, height: '100vh', width: RAIL_W,
+          background: t.railBg, borderRight: `1px solid ${t.border}`,
+          display: 'flex', flexDirection: 'column', alignItems: 'center',
+          zIndex: 50, padding: '8px 0', gap: '2px',
+        }}>
           <div style={{ width: RAIL_W, height: 48, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
             <img src="/favicon.png" alt="hub" style={{ width: 28, height: 28, objectFit: 'contain' }} />
           </div>
@@ -1007,7 +1012,7 @@ const DesktopNav: React.FC<{
                 {readingModeMenuOpen && (
                   <div style={{
                     position: 'absolute', left: '100%', top: 0, marginLeft: '8px', width: '190px', padding: '8px',
-                    borderRadius: '10px', border: `1px solid ${t.border}`, background: t.panelBg, boxShadow: t.elevatedShadow, zIndex: 70,
+                    borderRadius: '10px', border: `1px solid ${t.border}`, background: t.panelBg, boxShadow: 'none', zIndex: 70,
                   }}>
                     <button onClick={() => { setReadingMode('standard'); setReadingModeMenuOpen(false); }}
                       style={{ width: '100%', textAlign: 'left', border: 'none', borderRadius: '8px', padding: '8px 10px', cursor: 'pointer', background: readingMode === 'standard' ? t.accentSoft : 'transparent', color: t.fg, fontSize: '0.8rem' }}>
@@ -1074,7 +1079,6 @@ const DesktopNav: React.FC<{
           )}
         </aside>
       )}
-
       {railVisible && !isStandardMode && (
         <PanelResizeToggle isDark={isDark} panelOpen={panelOpen} panelWidth={panelWidth} onResizeMouseDown={onResizeMouseDown}
           onToggle={() => { if (activePanel) { setActivePanel(null); } else { handleTogglePanel('nav'); } }} />
@@ -1111,7 +1115,6 @@ const DesktopNav: React.FC<{
           </div>
         </aside>
       )}
-
       {isStandardMode && !standardTocVisible && (
         <button
           onClick={() => setStandardTocVisible(true)}
@@ -1162,7 +1165,11 @@ const MobilePanel: React.FC<{
   const PANEL_TITLES: Record<string, string> = { nav: 'Навигация', toc: 'Оглавление', contacts: 'Контакты' };
 
   return createPortal(
-    <div style={{ position: 'fixed', inset: 0, zIndex: 62, background: t.panelFullBg, display: 'flex', flexDirection: 'column', overflow: 'hidden', animation: 'mobPanelIn 0.22s cubic-bezier(0.4,0,0.2,1)', paddingBottom: '60px' }}>
+    <div style={{
+      position: 'fixed', inset: 0, zIndex: 62, background: t.panelFullBg, display: 'flex',
+      flexDirection: 'column', overflow: 'hidden', animation: 'mobPanelIn 0.22s cubic-bezier(0.4,0,0.2,1)',
+      paddingBottom: '60px',
+    }}>
       <style>{`@keyframes mobPanelIn{from{transform:translateY(100%)}to{transform:translateY(0)}}`}</style>
       <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '52px 20px 16px', borderBottom: `1px solid ${t.border}`, background: t.panelFullBg }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
@@ -1226,7 +1233,10 @@ const MobileNav: React.FC<{
         background: `linear-gradient(to bottom, transparent, ${t.mobBg})`,
       }} />
 
-      <nav style={{ position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 60, height: '60px', background: t.mobBg, borderTop: `1px solid ${t.border}`, display: 'flex', alignItems: 'stretch' }}>
+      <nav style={{
+        position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 60, height: '60px',
+        background: t.mobBg, borderTop: `1px solid ${t.border}`, display: 'flex', alignItems: 'stretch',
+      }}>
         <MobBtn label="Тема" icon={isDark ? <Sun size={22} /> : <Moon size={22} />} isDark={isDark} onClick={toggleTheme} isActive={false} />
         <MobBtn label="Поиск" icon={<Search size={22} />} isDark={isDark} onClick={() => { setSheet(null); setSearchOpen(true); }} isActive={false} />
 

--- a/src/features/navigation/components/UnifiedSearchPanel.tsx
+++ b/src/features/navigation/components/UnifiedSearchPanel.tsx
@@ -42,6 +42,9 @@ interface DocMeta {
 
 type DateFilter = 'all' | 'new' | 'updated';
 type SortOrder  = 'date-desc' | 'date-asc';
+interface SiteConfig {
+  useLanding?: boolean;
+}
 
 const PAGE_SIZE      = 10;
 const LOAD_MORE_N    = 10;
@@ -80,7 +83,8 @@ function fmtDate(d: string): string {
 }
 
 function getDocUrl(doc: DocMeta): string {
-  return doc.slug === 'welcome' ? '/' : `/${doc.slug}/`;
+  if (doc.slug === '' || doc.slug === 'welcome') return '/';
+  return `/${doc.slug}/`;
 }
 
 function pluralResults(n: number): string {
@@ -419,6 +423,50 @@ function useSearchResults(docs: DocMeta[], opts: SearchOptions) {
   }, [debouncedQ, docs, filterCategory, filterSection, activeTags, dateFilter, sortOrder]);
 }
 
+function useSearchDocs(manifestDocs: DocMeta[]): DocMeta[] {
+  const [useLanding, setUseLanding] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    fetch('/data/site-config.json')
+      .then(res => {
+        if (!res.ok) return { useLanding: false } as SiteConfig;
+        return res.json() as Promise<SiteConfig>;
+      })
+      .then(cfg => {
+        if (!active) return;
+        setUseLanding(cfg.useLanding === true);
+      })
+      .catch(() => {
+        if (!active) return;
+        setUseLanding(false);
+      });
+
+    return () => { active = false; };
+  }, []);
+
+  return useMemo(() => {
+    const withoutWelcome = manifestDocs.filter(d => !(d.slug === '' || d.slug === 'welcome' || d.id === 'welcome'));
+    if (!useLanding) return manifestDocs;
+
+    const landingDoc: DocMeta = {
+      id: 'landing-home',
+      slug: '',
+      title: 'Главная страница',
+      description: 'Лендинг Opensophy: быстрый доступ к разделам, материалам и инструментам проекта.',
+      type: '',
+      navSlug: '',
+      navTitle: 'Главная',
+      icon: 'crown',
+      tags: ['landing', 'главная', 'opensophy'],
+      lang: 'ru',
+    };
+
+    return [landingDoc, ...withoutWelcome];
+  }, [manifestDocs, useLanding]);
+}
+
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 const UnifiedSearchPanel: React.FC<UnifiedSearchPanelProps> = ({ onClose }) => {
@@ -442,7 +490,7 @@ const UnifiedSearchPanel: React.FC<UnifiedSearchPanelProps> = ({ onClose }) => {
   const listRef    = useRef<HTMLDivElement>(null);
   const debouncedQ = useDebounce(query, 200);
 
-  const typedDocs = docs as DocMeta[];
+  const typedDocs = useSearchDocs(docs as DocMeta[]);
 
   const { allCategories, allTags, allSections, hasUpdatedDocs } = useSearchFilters(typedDocs);
 


### PR DESCRIPTION
### Motivation
- Provide a toggleable DotWave background for documentation hero so projects can opt out of the decorative background while keeping a sane default.
- Persist the new option in the site config and surface it in the dev panel so developers can control it at runtime.
- Make search and routing respect empty/welcome slugs and optionally show a landing doc when `useLanding` is enabled.

### Description
- Added `showDotWaveBackground` (default `true`) to `public/data/site-config.json` and made `devBridge` return/initialize this flag when reading site config in `scripts/devBridge.mjs`.
- Extended the `SiteConfig` type in `src/features/dev-panel/useDevBridge.ts` to include `showDotWaveBackground` and added read/write handling for it in the dev panel UI (`SitePanel.tsx`) with a new toggle and handler `handleToggleDotWave`.
- Updated document rendering in `src/features/docs/components/DocContent.tsx` to fetch `/data/site-config.json`, pass `showDotWaveBackground` to `DocHero`, conditionally render `<DotWaveBackground />`, and adjust hero/background/meta colors and content container styling (rounded card, shadows, paddings).
- Improved search and routing in `src/features/navigation/components/UnifiedSearchPanel.tsx` by treating empty/welcome slugs as the site root in `getDocUrl`, and added `useSearchDocs` to load `useLanding` from site config and inject a synthetic landing document at the top of results when enabled.
- Miscellaneous UI/style tweaks in navigation components: removed some dropdown/panel shadows and normalized inline style objects for mobile/rail layouts.

### Testing
- Ran TypeScript type-check (`tsc --noEmit`) to validate types and the changes passed without errors.
- No new automated unit tests were added for these UI/behavior changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef714e717883248a19d13898e867df)