### PR TITLE
Add configurable Doc hero DotWave background and related UI tweaks

### DIFF
--- a/public/data/site-config.json
+++ b/public/data/site-config.json
@@ -1,3 +1,4 @@
 {
-  "useLanding": true
+  "useLanding": true,
+  "showDotWaveBackground": true
 }

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -7,7 +7,7 @@
   <!-- Главная страница -->
   <url>
     <loc>https://opensophy.com/</loc>
-    <lastmod>2026-04-23</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/scripts/devBridge.mjs
+++ b/scripts/devBridge.mjs
@@ -236,13 +236,16 @@ async function handleRenderPreview({ markdown }) {
 async function handleReadSiteConfig() {
   try {
     if (!fs.existsSync(SITE_CONFIG_PATH)) {
-      return { config: { useLanding: false } };
+      return { config: { useLanding: false, showDotWaveBackground: true } };
     }
     const raw = await fs.promises.readFile(SITE_CONFIG_PATH, 'utf-8');
     const config = JSON.parse(raw);
+    if (typeof config.showDotWaveBackground !== 'boolean') {
+      config.showDotWaveBackground = true;
+    }
     return { config };
   } catch {
-    return { config: { useLanding: false } };
+    return { config: { useLanding: false, showDotWaveBackground: true } };
   }
 }
 

--- a/src/features/dev-panel/panels/SitePanel.tsx
+++ b/src/features/dev-panel/panels/SitePanel.tsx
@@ -8,7 +8,7 @@ import type { SiteConfig } from '../useDevBridge';
 export default function SitePanel() {
   const t = useContext(ThemeTokensContext);
 
-  const [config, setConfig]   = useState<SiteConfig>({ useLanding: false });
+  const [config, setConfig]   = useState<SiteConfig>({ useLanding: false, showDotWaveBackground: true });
   const [loading, setLoading] = useState(true);
   const [saving, setSaving]   = useState(false);
   const [error, setError]     = useState('');
@@ -21,7 +21,10 @@ export default function SitePanel() {
     setError('');
     try {
       const { config: cfg } = await bridge.readSiteConfig();
-      setConfig(cfg);
+      setConfig({
+        useLanding: cfg.useLanding === true,
+        showDotWaveBackground: cfg.showDotWaveBackground !== false,
+      });
     } catch (e: unknown) {
       setError((e as Error).message);
     } finally {
@@ -40,6 +43,23 @@ export default function SitePanel() {
     try {
       await bridge.writeSiteConfig(next);
       toast.success(value ? 'Лендинг включён' : 'Welcome.md включён');
+    } catch (e: unknown) {
+      setError((e as Error).message);
+      setConfig(prevConfig.current);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggleDotWave = async (value: boolean) => {
+    const next = { ...config, showDotWaveBackground: value };
+    prevConfig.current = config;
+    setConfig(next);
+    setSaving(true);
+    setError('');
+    try {
+      await bridge.writeSiteConfig(next);
+      toast.success(value ? 'DotWave фон включён' : 'DotWave фон отключён');
     } catch (e: unknown) {
       setError((e as Error).message);
       setConfig(prevConfig.current);
@@ -184,6 +204,35 @@ export default function SitePanel() {
       {/* Разделитель */}
       <div style={{ height: 1, background: t.border, margin: '8px 0 12px' }} />
 
+      {/* Настройки hero-фона документации */}
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        marginBottom: 10, padding: '10px 12px',
+        borderRadius: 7, border: `1px solid ${t.border}`, background: t.surface,
+      }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <span style={{ fontSize: 11, color: t.fgMuted, fontWeight: 600 }}>DotWave фон в шапке документа</span>
+          <span style={{ fontSize: 10, color: t.fgSub }}>Если выключить, фон будет как у навигации.</span>
+        </div>
+        <button
+          disabled={saving}
+          onClick={() => handleToggleDotWave(!(config.showDotWaveBackground ?? true))}
+          style={{
+            border: `1px solid ${t.border}`,
+            background: (config.showDotWaveBackground ?? true) ? t.accentSoft : 'transparent',
+            color: t.fgMuted,
+            borderRadius: 6,
+            padding: '5px 9px',
+            fontSize: 10,
+            fontFamily: t.mono,
+            cursor: saving ? 'not-allowed' : 'pointer',
+            opacity: saving ? 0.7 : 1,
+          }}
+        >
+          {(config.showDotWaveBackground ?? true) ? 'ВКЛ' : 'ВЫКЛ'}
+        </button>
+      </div>
+
       {/* Текущее состояние */}
       <div style={{
         fontSize: 10, color: t.fgSub,
@@ -191,7 +240,7 @@ export default function SitePanel() {
       }}>
         <span>
           Сейчас: <strong style={{ color: t.fgMuted }}>
-            {config.useLanding ? 'Лендинг' : 'Welcome.md'}
+            {config.useLanding ? 'Лендинг' : 'Welcome.md'} · DotWave: {(config.showDotWaveBackground ?? true) ? 'вкл' : 'выкл'}
           </strong>
         </span>
         <button

--- a/src/features/dev-panel/useDevBridge.ts
+++ b/src/features/dev-panel/useDevBridge.ts
@@ -141,6 +141,7 @@ export function useDevBridge() {
 
 export interface SiteConfig {
   useLanding: boolean;
+  showDotWaveBackground?: boolean;
 }
 
 // ─── Typed bridge API ──────────────────────────────────────────────────────────

--- a/src/features/docs/components/DocContent.tsx
+++ b/src/features/docs/components/DocContent.tsx
@@ -74,18 +74,21 @@ interface DocHeroProps {
   isDark: boolean;
   readTime: number;
   liveFM?: LiveFM | null;
+  showDotWaveBackground: boolean;
 }
 
-const DocHero: React.FC<DocHeroProps> = ({ doc, isDark, readTime, liveFM }) => {
+const DocHero: React.FC<DocHeroProps> = ({ doc, isDark, readTime, liveFM, showDotWaveBackground }) => {
   const title       = liveFM?.title?.trim()       || doc.title;
   const description = liveFM?.description?.trim() || doc.description;
   const author      = liveFM?.author?.trim()       || doc.author;
   const date        = liveFM?.date?.trim()         || doc.date;
   const updated     = liveFM?.updated?.trim()      || doc.updated;
 
-  const heroBg      = isDark ? '#0a0a0a' : '#E8E7E3';
+  const heroBg      = showDotWaveBackground
+    ? (isDark ? '#0a0a0a' : '#E8E7E3')
+    : (isDark ? '#0F0F0F' : '#E0DFDb');
   const borderColor = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
-  const metaClr     = isDark ? 'rgba(255,255,255,0.45)' : 'rgba(0,0,0,0.75)';
+  const metaClr     = isDark ? '#ffffff' : '#000000';
   const badgeBg     = isDark ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.06)';
   const badgeBdr    = isDark ? 'rgba(255,255,255,0.1)'  : 'rgba(0,0,0,0.1)';
   const textPrimary = isDark ? '#ffffff' : '#000000';
@@ -98,7 +101,7 @@ const DocHero: React.FC<DocHeroProps> = ({ doc, isDark, readTime, liveFM }) => {
   return (
     <div style={{ background: heroBg, borderBottom: `1px solid ${borderColor}`, padding: '3rem 2rem 2.5rem', position: 'relative' }}>
       <div style={{ position: 'absolute', inset: 0, overflow: 'hidden', pointerEvents: 'none', contain: 'strict' }}>
-        <DotWaveBackground isDark={isDark} />
+        {showDotWaveBackground && <DotWaveBackground isDark={isDark} />}
       </div>
       <div style={{ position: 'relative', zIndex: 1 }}>
         {doc.typename?.trim() && (
@@ -169,6 +172,7 @@ const DocHero: React.FC<DocHeroProps> = ({ doc, isDark, readTime, liveFM }) => {
 const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
   const { isDark } = useTheme();
   const [fullscreenTableHtml, setFullscreenTableHtml] = useState<string | null>(null);
+  const [showDotWaveBackground, setShowDotWaveBackground] = useState(true);
 
   const [isDesktop, setIsDesktop] = useState(false);
   const [navLeft, setNavLeft]     = useState('0px');
@@ -213,6 +217,21 @@ const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
     observer.observe(document.documentElement, { attributes: true, attributeFilter: ['style'] });
     return () => observer.disconnect();
   }, [isDesktop]);
+
+  useEffect(() => {
+    let mounted = true;
+    fetch('/data/site-config.json')
+      .then(r => (r.ok ? r.json() : { showDotWaveBackground: true }))
+      .then(cfg => {
+        if (!mounted) return;
+        setShowDotWaveBackground(cfg.showDotWaveBackground !== false);
+      })
+      .catch(() => {
+        if (!mounted) return;
+        setShowDotWaveBackground(true);
+      });
+    return () => { mounted = false; };
+  }, []);
 
   // ── Live preview via BroadcastChannel ────────────────────────────────────
   const [liveHtml, setLiveHtml] = useState<string | null>(null);
@@ -265,7 +284,6 @@ const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
     () => ({ onTableClick: (html: string) => setFullscreenTableHtml(html), isDark }),
     [isDark]
   );
-
   return (
     <div style={{ minHeight: '100vh' }}>
       {/* Progress bar */}
@@ -285,7 +303,13 @@ const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
           transition:   'none',
         }}
       >
-        <DocHero doc={doc} isDark={isDark} readTime={readTime} liveFM={liveFM} />
+        <DocHero
+          doc={doc}
+          isDark={isDark}
+          readTime={readTime}
+          liveFM={liveFM}
+          showDotWaveBackground={showDotWaveBackground}
+        />
 
         <article style={{
           padding: '2rem 2rem 3rem',

--- a/src/features/navigation/components/Navigation.tsx
+++ b/src/features/navigation/components/Navigation.tsx
@@ -679,7 +679,7 @@ const NavPanelContent: React.FC<{
               background: t.dropdownBg,
               zIndex: 100,
               overflow: 'hidden',
-              boxShadow: t.dropdownShadow,
+              boxShadow: 'none',
             }}>
               <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', padding: '8px' }}>
                 <SectionDropdown sections={sections} activeNavSlug={activeNavSlug} mobile={!!mobile} isDark={isDark} onSelect={handleSectionSelect} />
@@ -690,7 +690,7 @@ const NavPanelContent: React.FC<{
       )}
 
       {/* Дерево навигации */}
-      <div style={{ flex: 1, overflowY: 'auto', padding: mobile ? '8px 6px' : '6px' }}>
+      <div style={{ flex: 1, overflowY: 'auto', padding: mobile ? '8px 6px 86px' : '6px' }}>
         <NavTreeContent
           error={!!error} loading={loading} navTree={navTree}
           currentDocSlug={currentDocSlug} expandedPaths={expandedPaths}
@@ -902,7 +902,7 @@ const PanelResizeToggle: React.FC<{
           background: getPanelToggleBackground(hov, isDark),
           color: hov ? t.fg : t.fgMuted, cursor: 'pointer', padding: 0,
           display: 'flex', alignItems: 'center', justifyContent: 'center',
-          boxShadow: hov ? t.elevatedShadowSoft : 'none',
+          boxShadow: 'none',
         }}>
         {panelOpen ? <ChevronLeft size={11} strokeWidth={2.5} /> : <ChevronRight size={11} strokeWidth={2.5} />}
       </button>
@@ -961,16 +961,17 @@ const DesktopNav: React.FC<{
   }, [standardTocVisible]);
 
   useEffect(() => {
-    const panelOffset = panelOpen ? panelWidth : 0;
+    const isDocsPage = Boolean(currentDocSlug);
+    const panelOffset = isDocsPage && panelOpen ? panelWidth : 0;
     const left = railVisible ? RAIL_W + panelOffset : 0;
-    const sidebarHidden = isStandardMode && !railVisible;
-    const tocHidden = isStandardMode && !standardTocVisible;
+    const sidebarHidden = isDocsPage && isStandardMode && !railVisible;
+    const tocHidden = isDocsPage && isStandardMode && !standardTocVisible;
     document.documentElement.style.setProperty('--nav-left', `${left}px`);
-    document.documentElement.style.setProperty('--doc-right', isStandardMode && standardTocVisible ? `${TOC_PANEL_W}px` : '0px');
+    document.documentElement.style.setProperty('--doc-right', isDocsPage && isStandardMode && standardTocVisible ? `${TOC_PANEL_W}px` : '0px');
     document.documentElement.style.setProperty('--doc-border-left', sidebarHidden ? '1' : '0');
     document.documentElement.style.setProperty('--doc-border-right', tocHidden ? '1' : '0');
     return () => { document.documentElement.style.removeProperty('--nav-left'); };
-  }, [railVisible, panelOpen, panelWidth, isStandardMode, standardTocVisible]);
+  }, [railVisible, panelOpen, panelWidth, isStandardMode, standardTocVisible, currentDocSlug]);
 
   useEffect(() => {
     return () => {
@@ -985,7 +986,15 @@ const DesktopNav: React.FC<{
   return (
     <>
       {railVisible && (
-        <aside style={{ position: 'fixed', left: 0, top: 0, height: '100vh', width: RAIL_W, background: t.railBg, borderRight: `1px solid ${t.border}`, display: 'flex', flexDirection: 'column', alignItems: 'center', zIndex: 50, padding: '8px 0', gap: '2px' }}>
+        <aside style={{
+          position: 'fixed', left: 0, top: 0, height: '100vh', width: RAIL_W,
+          background: isDark ? 'rgba(15,15,15,0.84)' : 'rgba(224,223,219,0.82)',
+          borderRight: `1px solid ${t.border}`,
+          display: 'flex', flexDirection: 'column', alignItems: 'center',
+          zIndex: 50, padding: '8px 0', gap: '2px',
+          backdropFilter: 'blur(12px)',
+          WebkitBackdropFilter: 'blur(12px)',
+        }}>
           <div style={{ width: RAIL_W, height: 48, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
             <img src="/favicon.png" alt="hub" style={{ width: 28, height: 28, objectFit: 'contain' }} />
           </div>
@@ -1007,7 +1016,7 @@ const DesktopNav: React.FC<{
                 {readingModeMenuOpen && (
                   <div style={{
                     position: 'absolute', left: '100%', top: 0, marginLeft: '8px', width: '190px', padding: '8px',
-                    borderRadius: '10px', border: `1px solid ${t.border}`, background: t.panelBg, boxShadow: t.elevatedShadow, zIndex: 70,
+                    borderRadius: '10px', border: `1px solid ${t.border}`, background: t.panelBg, boxShadow: 'none', zIndex: 70,
                   }}>
                     <button onClick={() => { setReadingMode('standard'); setReadingModeMenuOpen(false); }}
                       style={{ width: '100%', textAlign: 'left', border: 'none', borderRadius: '8px', padding: '8px 10px', cursor: 'pointer', background: readingMode === 'standard' ? t.accentSoft : 'transparent', color: t.fg, fontSize: '0.8rem' }}>
@@ -1044,9 +1053,12 @@ const DesktopNav: React.FC<{
         <aside style={{
           position: 'fixed', left: RAIL_W, top: 0, height: '100vh',
           width: panelOpen ? panelWidth : 0,
-          background: t.panelBg, borderRight: panelOpen ? `1px solid ${t.border}` : 'none',
+          background: isDark ? 'rgba(15,15,15,0.78)' : 'rgba(224,223,219,0.78)',
+          borderRight: panelOpen ? `1px solid ${t.border}` : 'none',
           display: 'flex', flexDirection: 'column', zIndex: 49, overflow: 'hidden',
           pointerEvents: panelOpen ? 'auto' : 'none', visibility: panelOpen ? 'visible' : 'hidden',
+          backdropFilter: 'blur(14px)',
+          WebkitBackdropFilter: 'blur(14px)',
         }}>
           {panelOpen && (
             <>
@@ -1074,7 +1086,6 @@ const DesktopNav: React.FC<{
           )}
         </aside>
       )}
-
       {railVisible && !isStandardMode && (
         <PanelResizeToggle isDark={isDark} panelOpen={panelOpen} panelWidth={panelWidth} onResizeMouseDown={onResizeMouseDown}
           onToggle={() => { if (activePanel) { setActivePanel(null); } else { handleTogglePanel('nav'); } }} />
@@ -1083,8 +1094,12 @@ const DesktopNav: React.FC<{
       {isStandardMode && standardTocVisible && (
         <aside style={{
           position: 'fixed', right: 0, top: 0, width: TOC_PANEL_W, height: '100vh',
-          borderLeft: `1px solid ${t.border}`, background: t.panelBg, zIndex: 48,
+          borderLeft: `1px solid ${t.border}`,
+          background: isDark ? 'rgba(15,15,15,0.78)' : 'rgba(224,223,219,0.78)',
+          zIndex: 48,
           display: 'flex', flexDirection: 'column',
+          backdropFilter: 'blur(14px)',
+          WebkitBackdropFilter: 'blur(14px)',
         }}>
           <div style={{ borderBottom: `1px solid ${t.border}`, padding: '10px 12px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <span style={{ fontSize: '0.72rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', color: t.fgMuted }}>Оглавление</span>
@@ -1111,7 +1126,6 @@ const DesktopNav: React.FC<{
           </div>
         </aside>
       )}
-
       {isStandardMode && !standardTocVisible && (
         <button
           onClick={() => setStandardTocVisible(true)}
@@ -1162,7 +1176,11 @@ const MobilePanel: React.FC<{
   const PANEL_TITLES: Record<string, string> = { nav: 'Навигация', toc: 'Оглавление', contacts: 'Контакты' };
 
   return createPortal(
-    <div style={{ position: 'fixed', inset: 0, zIndex: 62, background: t.panelFullBg, display: 'flex', flexDirection: 'column', overflow: 'hidden', animation: 'mobPanelIn 0.22s cubic-bezier(0.4,0,0.2,1)', paddingBottom: '60px' }}>
+    <div style={{
+      position: 'fixed', inset: 0, zIndex: 62, background: t.panelFullBg, display: 'flex',
+      flexDirection: 'column', overflow: 'hidden', animation: 'mobPanelIn 0.22s cubic-bezier(0.4,0,0.2,1)',
+      paddingBottom: '60px',
+    }}>
       <style>{`@keyframes mobPanelIn{from{transform:translateY(100%)}to{transform:translateY(0)}}`}</style>
       <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '52px 20px 16px', borderBottom: `1px solid ${t.border}`, background: t.panelFullBg }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
@@ -1179,6 +1197,25 @@ const MobilePanel: React.FC<{
         {type === 'toc'      && <div style={{ flex: 1, overflowY: 'auto' }}><TocPanelContent toc={toc} activeId={activeId} isDark={isDark} onItemClick={onClose} mobile /></div>}
         {type === 'contacts' && <div style={{ overflowY: 'auto' }}><ContactsPanelContent isDark={isDark} mobile /></div>}
       </div>
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          bottom: '60px',
+          height: '42px',
+          pointerEvents: 'none',
+          background: isDark
+            ? 'linear-gradient(to top, rgba(10,10,10,0.95), rgba(10,10,10,0.55), transparent)'
+            : 'linear-gradient(to top, rgba(232,231,227,0.95), rgba(232,231,227,0.6), transparent)',
+          boxShadow: isDark
+            ? '0 -12px 30px rgba(0,0,0,0.35) inset'
+            : '0 -10px 24px rgba(0,0,0,0.14) inset',
+          backdropFilter: 'blur(6px)',
+          WebkitBackdropFilter: 'blur(6px)',
+        }}
+      />
     </div>,
     document.body,
   );
@@ -1226,7 +1263,10 @@ const MobileNav: React.FC<{
         background: `linear-gradient(to bottom, transparent, ${t.mobBg})`,
       }} />
 
-      <nav style={{ position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 60, height: '60px', background: t.mobBg, borderTop: `1px solid ${t.border}`, display: 'flex', alignItems: 'stretch' }}>
+      <nav style={{
+        position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 60, height: '60px',
+        background: t.mobBg, borderTop: `1px solid ${t.border}`, display: 'flex', alignItems: 'stretch',
+      }}>
         <MobBtn label="Тема" icon={isDark ? <Sun size={22} /> : <Moon size={22} />} isDark={isDark} onClick={toggleTheme} isActive={false} />
         <MobBtn label="Поиск" icon={<Search size={22} />} isDark={isDark} onClick={() => { setSheet(null); setSearchOpen(true); }} isActive={false} />
 

--- a/src/features/navigation/components/UnifiedSearchPanel.tsx
+++ b/src/features/navigation/components/UnifiedSearchPanel.tsx
@@ -42,6 +42,9 @@ interface DocMeta {
 
 type DateFilter = 'all' | 'new' | 'updated';
 type SortOrder  = 'date-desc' | 'date-asc';
+interface SiteConfig {
+  useLanding?: boolean;
+}
 
 const PAGE_SIZE      = 10;
 const LOAD_MORE_N    = 10;
@@ -80,7 +83,8 @@ function fmtDate(d: string): string {
 }
 
 function getDocUrl(doc: DocMeta): string {
-  return doc.slug === 'welcome' ? '/' : `/${doc.slug}/`;
+  if (doc.slug === '' || doc.slug === 'welcome') return '/';
+  return `/${doc.slug}/`;
 }
 
 function pluralResults(n: number): string {
@@ -419,6 +423,50 @@ function useSearchResults(docs: DocMeta[], opts: SearchOptions) {
   }, [debouncedQ, docs, filterCategory, filterSection, activeTags, dateFilter, sortOrder]);
 }
 
+function useSearchDocs(manifestDocs: DocMeta[]): DocMeta[] {
+  const [useLanding, setUseLanding] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    fetch('/data/site-config.json')
+      .then(res => {
+        if (!res.ok) return { useLanding: false } as SiteConfig;
+        return res.json() as Promise<SiteConfig>;
+      })
+      .then(cfg => {
+        if (!active) return;
+        setUseLanding(cfg.useLanding === true);
+      })
+      .catch(() => {
+        if (!active) return;
+        setUseLanding(false);
+      });
+
+    return () => { active = false; };
+  }, []);
+
+  return useMemo(() => {
+    const withoutWelcome = manifestDocs.filter(d => !(d.slug === '' || d.slug === 'welcome' || d.id === 'welcome'));
+    if (!useLanding) return manifestDocs;
+
+    const landingDoc: DocMeta = {
+      id: 'landing-home',
+      slug: '',
+      title: 'Главная страница',
+      description: 'Лендинг Opensophy: быстрый доступ к разделам, материалам и инструментам проекта.',
+      type: '',
+      navSlug: '',
+      navTitle: 'Главная',
+      icon: 'crown',
+      tags: ['landing', 'главная', 'opensophy'],
+      lang: 'ru',
+    };
+
+    return [landingDoc, ...withoutWelcome];
+  }, [manifestDocs, useLanding]);
+}
+
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 const UnifiedSearchPanel: React.FC<UnifiedSearchPanelProps> = ({ onClose }) => {
@@ -442,7 +490,7 @@ const UnifiedSearchPanel: React.FC<UnifiedSearchPanelProps> = ({ onClose }) => {
   const listRef    = useRef<HTMLDivElement>(null);
   const debouncedQ = useDebounce(query, 200);
 
-  const typedDocs = docs as DocMeta[];
+  const typedDocs = useSearchDocs(docs as DocMeta[]);
 
   const { allCategories, allTags, allSections, hasUpdatedDocs } = useSearchFilters(typedDocs);
 


### PR DESCRIPTION
### Motivation
- Add a user-configurable option to enable/disable the DotWave decorative background in documentation hero areas and persist it in site config.
- Surface the new option in the dev panel so it can be toggled during development without editing files manually.
- Improve navigation and panel visuals and fix URL/landing handling in search results.

### Description
- Add `showDotWaveBackground` to `public/data/site-config.json` and treat it as `true` by default in `scripts/devBridge.mjs` read/fallback logic and error paths.
- Extend `SiteConfig` type in `useDevBridge.ts` and wire `readSiteConfig`/`writeSiteConfig` usage so the dev bridge preserves the new flag.
- Add a toggle UI and handler `handleToggleDotWave` to `SitePanel.tsx`, initialize state to default `true`, and persist changes via `bridge.writeSiteConfig`.
- Make `DocContent` fetch `/data/site-config.json` and pass `showDotWaveBackground` to `DocHero`, which now conditionally renders `DotWaveBackground` and adjusts hero colors when the flag is off.
- Update `UnifiedSearchPanel` to treat empty slug or `welcome` as root URL in `getDocUrl`, and introduce `useSearchDocs` to inject a synthetic landing doc when `useLanding` is enabled in site config.
- Tweak navigation/panel UI styles and layout (padding, backdrop blur, box-shadow removals, mobile panel gradient, panel offsets) and adjust computed CSS variables to respect whether a docs page is open.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef714e717883248a19d13898e867df)