### PR TITLE
fix(mobile-nav): remove duplicate bottom overlays in mobile sheets

### DIFF
--- a/src/features/navigation/components/Navigation.tsx
+++ b/src/features/navigation/components/Navigation.tsx
@@ -1114,20 +1114,6 @@ const MobilePanel: React.FC<{
         {type === 'toc'      && <div style={{ flex: 1, overflowY: 'auto' }}><TocPanelContent toc={toc} activeId={activeId} isDark={isDark} onItemClick={onClose} mobile /></div>}
         {type === 'contacts' && <div style={{ overflowY: 'auto' }}><ContactsPanelContent isDark={isDark} mobile /></div>}
       </div>
-      <div
-        aria-hidden="true"
-        style={{
-          position: 'absolute', left: 0, right: 0, bottom: '60px', height: '42px',
-          pointerEvents: 'none',
-          background: isDark
-            ? 'linear-gradient(to top, rgba(10,10,10,0.95), rgba(10,10,10,0.55), transparent)'
-            : 'linear-gradient(to top, rgba(232,231,227,0.95), rgba(232,231,227,0.6), transparent)',
-          boxShadow: isDark
-            ? '0 -12px 30px rgba(0,0,0,0.35) inset'
-            : '0 -10px 24px rgba(0,0,0,0.14) inset',
-          backdropFilter: 'blur(6px)', WebkitBackdropFilter: 'blur(6px)',
-        }}
-      />
     </div>,
     document.body,
   );
@@ -1163,11 +1149,6 @@ const MobileNav: React.FC<{
   return (
     <>
       {sheet && <MobilePanel type={sheet} onClose={() => setSheet(null)} isDark={isDark} currentDocSlug={currentDocSlug} toc={toc} activeId={activeId} />}
-
-      <div style={{
-        position: 'fixed', bottom: '60px', left: 0, right: 0, zIndex: 59, height: '52px',
-        pointerEvents: 'none', background: `linear-gradient(to bottom, transparent, ${t.mobBg})`,
-      }} />
 
       <nav style={{
         position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 60, height: '60px',


### PR DESCRIPTION
### Motivation
- Mobile panels (e.g. `Contacts`) showed a visible double-layer at the bottom (a blur backdrop plus an additional opaque/gradient strip), producing an unwanted visual artifact.
- Remove the decorative overlays to make the mobile sheet appearance consistent and avoid stacking backdrops.

### Description
- Deleted the bottom gradient/blur overlay from `MobilePanel` in `src/features/navigation/components/Navigation.tsx`.
- Deleted the fixed gradient strip above the mobile bottom nav in `MobileNav` in the same file.
- The change is limited to removing those two decorative elements and does not alter navigation logic or panel behavior.

### Testing
- Ran `npm run lint`; it failed due to pre-existing repository lint errors unrelated to this change.
- No automated unit or integration tests were added or executed for this cosmetic change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0876deec08324bbdad8b9ef8c5cd8)