### PR TITLE
Fix navigation logo swap without favicon flash

### DIFF
--- a/src/features/navigation/components/Navigation.tsx
+++ b/src/features/navigation/components/Navigation.tsx
@@ -59,7 +59,7 @@ interface SiteLogoConfig {
 }
 
 function getThemeLogoPath(config: SiteLogoConfig, isDark: boolean): string {
-  return (isDark ? config.darkLogo || config.lightLogo : config.lightLogo || config.darkLogo) || '/favicon.png';
+  return isDark ? (config.darkLogo || config.lightLogo || '') : (config.lightLogo || config.darkLogo || '');
 }
 
 function toDocHref(slug?: string): string {
@@ -878,14 +878,20 @@ const PANEL_TITLES: Record<Exclude<PanelType, null>, string> = {
   contacts: 'Контакты',
 };
 
-const BrandLogo: React.FC<{ logoPath: string; size: number }> = ({ logoPath, size }) => (
-  <img
-    src={logoPath}
-    alt="hub"
-    onError={e => { if (e.currentTarget.src !== globalThis.location.origin + '/favicon.png') e.currentTarget.src = '/favicon.png'; }}
-    style={{ width: size, height: size, objectFit: 'contain' }}
-  />
-);
+const BrandLogo: React.FC<{ logoPath: string; size: number }> = ({ logoPath, size }) => {
+  if (!logoPath) return <span aria-hidden style={{ width: size, height: size, display: 'inline-block' }} />;
+
+  return (
+    <img
+      src={logoPath}
+      alt="hub"
+      onError={e => {
+        e.currentTarget.style.display = 'none';
+      }}
+      style={{ width: size, height: size, objectFit: 'contain' }}
+    />
+  );
+};
 
 const DesktopNav: React.FC<{
   isDark: boolean; toggleTheme: () => void; currentDocSlug?: string; toc: TocItem[]; activeId: string; showDocActions: boolean; logoPath: string;
@@ -1220,7 +1226,15 @@ const Navigation: React.FC<NavigationProps> = ({ currentDocSlug, toc = [], activ
   useEffect(() => {
     let alive = true;
     const applyLogoConfig = (cfg: SiteLogoConfig) => {
-      if (alive) setLogoConfig({ lightLogo: cfg.lightLogo || '', darkLogo: cfg.darkLogo || '' });
+      const next = { lightLogo: cfg.lightLogo || '', darkLogo: cfg.darkLogo || '' };
+
+      [next.lightLogo, next.darkLogo].forEach(src => {
+        if (!src) return;
+        const img = new Image();
+        img.src = src;
+      });
+
+      if (alive) setLogoConfig(next);
     };
     const onLogoChange = (e: Event) => applyLogoConfig((e as CustomEvent<SiteLogoConfig>).detail || {});
 


### PR DESCRIPTION
### Motivation
- Eliminate a brief flash of the site favicon inside the navigation when logos or theme change and make logo switching instantaneous.

### Description
- Removed the fallback to `/favicon.png` from `getThemeLogoPath` so the nav uses only `lightLogo`/`darkLogo` values.
- Updated `BrandLogo` to render a fixed-size placeholder when no logo is configured and to hide a broken `<img>` on load error instead of replacing it with the favicon.
- Preload both `lightLogo` and `darkLogo` after loading `site-config.json` so theme-based logo switching happens immediately without visual flicker.

### Testing
- Ran linter with `npm run -s lint -- src/features/navigation/components/Navigation.tsx`; the linter exited non-zero due to existing unrelated lint issues in the repository and not because of the changes in this file.
- No component/unit tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97f515a48832e893b8aed0a15e28f)