### PR TITLE
Add desktop chrome gap and rounded chrome styling for docs and nav

### DIFF
--- a/src/features/docs/components/DocContent.tsx
+++ b/src/features/docs/components/DocContent.tsx
@@ -180,6 +180,8 @@ const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
   const [isDesktop, setIsDesktop] = useState(false);
   const [navLeft, setNavLeft]     = useState('0px');
   const [docRight, setDocRight] = useState('0px');
+  const [docChromeGap, setDocChromeGap] = useState('0px');
+  const [docChromeRadius, setDocChromeRadius] = useState('0px');
   const [showLeftBorder, setShowLeftBorder] = useState(false);
   const [showRightBorder, setShowRightBorder] = useState(false);
 
@@ -200,6 +202,8 @@ const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
     if (!isDesktop) {
       setNavLeft('0px');
       setDocRight('0px');
+      setDocChromeGap('0px');
+      setDocChromeRadius('0px');
       setShowLeftBorder(false);
       setShowRightBorder(false);
       return;
@@ -209,9 +213,13 @@ const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
       const left = css.getPropertyValue('--nav-left').trim();
       const right = css.getPropertyValue('--doc-right').trim();
       const leftBorder = css.getPropertyValue('--doc-border-left').trim();
+      const chromeGap = css.getPropertyValue('--doc-chrome-gap').trim();
+      const chromeRadius = css.getPropertyValue('--doc-chrome-radius').trim();
       const rightBorder = css.getPropertyValue('--doc-border-right').trim();
       setNavLeft(left || '64px');
       setDocRight(right || '0px');
+      setDocChromeGap(chromeGap || '0px');
+      setDocChromeRadius(chromeRadius || '0px');
       setShowLeftBorder(leftBorder === '1');
       setShowRightBorder(rightBorder === '1');
     };
@@ -303,7 +311,13 @@ const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
           background: t.bgPage,
           marginLeft:   isDesktop ? navLeft : '0',
           marginRight:  isDesktop ? docRight : '0',
-          marginBottom: isDesktop ? '0' : '3.5rem',
+          marginTop:    isDesktop ? docChromeGap : '0',
+          marginBottom: isDesktop ? docChromeGap : '3.5rem',
+          minHeight:    isDesktop ? `calc(100vh - (${docChromeGap} * 2))` : '100vh',
+          border:       isDesktop ? `1px solid ${t.border}` : 'none',
+          borderRadius: isDesktop ? docChromeRadius : 0,
+          overflow:     isDesktop ? 'hidden' : 'visible',
+          boxShadow:    isDesktop ? `0 0 0 1px ${t.border}, inset 0 1px 0 rgba(255,255,255,0.03)` : 'none',
           transition:   'none',
         }}
       >

--- a/src/features/docs/components/DocContent.tsx
+++ b/src/features/docs/components/DocContent.tsx
@@ -182,6 +182,7 @@ const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
   const [docRight, setDocRight] = useState('0px');
   const [docChromeGap, setDocChromeGap] = useState('0px');
   const [docChromeRadius, setDocChromeRadius] = useState('0px');
+  const [docChromeTopGap, setDocChromeTopGap] = useState('0px');
   const [showLeftBorder, setShowLeftBorder] = useState(false);
   const [showRightBorder, setShowRightBorder] = useState(false);
 
@@ -204,6 +205,7 @@ const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
       setDocRight('0px');
       setDocChromeGap('0px');
       setDocChromeRadius('0px');
+      setDocChromeTopGap('0px');
       setShowLeftBorder(false);
       setShowRightBorder(false);
       return;
@@ -215,11 +217,13 @@ const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
       const leftBorder = css.getPropertyValue('--doc-border-left').trim();
       const chromeGap = css.getPropertyValue('--doc-chrome-gap').trim();
       const chromeRadius = css.getPropertyValue('--doc-chrome-radius').trim();
+      const chromeTopGap = css.getPropertyValue('--doc-chrome-top-gap').trim();
       const rightBorder = css.getPropertyValue('--doc-border-right').trim();
       setNavLeft(left || '64px');
       setDocRight(right || '0px');
       setDocChromeGap(chromeGap || '0px');
       setDocChromeRadius(chromeRadius || '0px');
+      setDocChromeTopGap(chromeTopGap || chromeGap || '0px');
       setShowLeftBorder(leftBorder === '1');
       setShowRightBorder(rightBorder === '1');
     };
@@ -297,7 +301,8 @@ const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
   );
   const navChromeBg = isDark ? 'rgba(15,15,15,0.84)' : 'rgba(224,223,219,0.82)';
   return (
-    <div style={{ minHeight: '100vh', background: isDesktop ? navChromeBg : t.bgPage }}>
+    <div style={{ minHeight: '100vh', background: isDesktop ? navChromeBg : t.bgPage, position: 'relative' }}>
+      {isDesktop && <div aria-hidden style={{ position: 'fixed', inset: 0, background: navChromeBg, zIndex: 0, pointerEvents: 'none' }} />}
       {/* Progress bar */}
       <div
         ref={progressBarRef}
@@ -312,9 +317,11 @@ const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
           background: t.bgPage,
           marginLeft:   isDesktop ? navLeft : '0',
           marginRight:  isDesktop ? docRight : '0',
-          marginTop:    isDesktop ? docChromeGap : '0',
+          position:     'relative',
+          zIndex:       1,
+          marginTop:    isDesktop ? docChromeTopGap : '0',
           marginBottom: isDesktop ? docChromeGap : '3.5rem',
-          minHeight:    isDesktop ? `calc(100vh - (${docChromeGap} * 2))` : '100vh',
+          minHeight:    isDesktop ? `calc(100vh - (${docChromeTopGap} + ${docChromeGap}))` : '100vh',
           border:       isDesktop ? `1px solid ${t.border}` : 'none',
           borderRadius: isDesktop ? docChromeRadius : 0,
           overflow:     isDesktop ? 'hidden' : 'visible',

--- a/src/features/docs/components/DocContent.tsx
+++ b/src/features/docs/components/DocContent.tsx
@@ -295,8 +295,9 @@ const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
     () => ({ onTableClick: (html: string) => setFullscreenTableHtml(html), isDark }),
     [isDark]
   );
+  const navChromeBg = isDark ? 'rgba(15,15,15,0.84)' : 'rgba(224,223,219,0.82)';
   return (
-    <div style={{ minHeight: '100vh' }}>
+    <div style={{ minHeight: '100vh', background: isDesktop ? navChromeBg : t.bgPage }}>
       {/* Progress bar */}
       <div
         ref={progressBarRef}

--- a/src/features/navigation/components/Navigation.tsx
+++ b/src/features/navigation/components/Navigation.tsx
@@ -33,6 +33,7 @@ const PANEL_MIN     = 220;
 const PANEL_MAX     = 500;
 const TOC_PANEL_W   = 300;
 const DOC_CHROME_GAP = 10;
+const DOC_CHROME_TOP_GAP = 14;
 const DOC_CHROME_RADIUS = 18;
 
 export interface TocItem { id: string; text: string; level: number; }
@@ -598,7 +599,7 @@ const NavPanelContent: React.FC<{
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
 
       {/* Строка поиска */}
-      <div style={{ flexShrink: 0, padding: mobile ? '12px 14px' : '10px', borderBottom: `1px solid ${t.border}` }}>
+      <div style={{ flexShrink: 0, padding: mobile ? '12px 14px' : '10px', borderBottom: 'none' }}>
         <div style={{ position: 'relative' }}>
           <Search size={iconSize} style={{ position: 'absolute', left: '0.75rem', top: '50%', transform: 'translateY(-50%)', color: t.fgSub, pointerEvents: 'none' }} />
           <input
@@ -627,7 +628,7 @@ const NavPanelContent: React.FC<{
       {sections.length > 1 && activeSection && (
         <div
           ref={sectionRef}
-          style={{ flexShrink: 0, padding: mobile ? '10px 14px' : '8px 10px', borderBottom: `1px solid ${t.border}`, position: 'relative', zIndex: 10 }}
+          style={{ flexShrink: 0, padding: mobile ? '10px 14px' : '8px 10px', borderBottom: 'none', position: 'relative', zIndex: 10 }}
         >
           <button
             onClick={() => setSectionOpen(v => !v)}
@@ -793,7 +794,7 @@ const ContactsPanelContent: React.FC<{ isDark: boolean; mobile?: boolean }> = ({
 const PanelHeader: React.FC<{ title: string; isDark: boolean; onClose: () => void }> = ({ title, isDark, onClose }) => {
   const t = tk(isDark);
   return (
-    <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '11px 12px 9px', borderBottom: `1px solid ${t.border}` }}>
+    <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '11px 12px 9px', borderBottom: 'none' }}>
       <span style={{ fontSize: '0.72rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', color: t.fgMuted }}>{title}</span>
       <button onClick={onClose}
         style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: 24, height: 24, borderRadius: '6px', border: 'none', background: 'transparent', color: t.fgMuted, cursor: 'pointer' }}
@@ -839,6 +840,7 @@ function buildCssVars(
   standardTocVisible: boolean,
 ): void {
   const chromeGap     = isDocsPage ? DOC_CHROME_GAP : 0;
+  const chromeTopGap  = isDocsPage ? DOC_CHROME_TOP_GAP : 0;
   const panelOffset   = isDocsPage && panelOpen ? panelWidth : 0;
   const left          = railVisible ? chromeGap + RAIL_W + panelOffset + chromeGap : chromeGap;
   const docRight      = isDocsPage && isStandardMode && standardTocVisible ? chromeGap + TOC_PANEL_W + chromeGap : chromeGap;
@@ -849,6 +851,7 @@ function buildCssVars(
   document.documentElement.style.setProperty('--doc-border-left', sidebarHidden ? '1' : '0');
   document.documentElement.style.setProperty('--doc-border-right', tocHidden ? '1' : '0');
   document.documentElement.style.setProperty('--doc-chrome-gap', `${chromeGap}px`);
+  document.documentElement.style.setProperty('--doc-chrome-top-gap', `${chromeTopGap}px`);
   document.documentElement.style.setProperty('--doc-chrome-radius', `${isDocsPage ? DOC_CHROME_RADIUS : 0}px`);
 }
 
@@ -857,6 +860,7 @@ function clearDocCssVars(): void {
   document.documentElement.style.removeProperty('--doc-border-left');
   document.documentElement.style.removeProperty('--doc-border-right');
   document.documentElement.style.removeProperty('--doc-chrome-gap');
+  document.documentElement.style.removeProperty('--doc-chrome-top-gap');
   document.documentElement.style.removeProperty('--doc-chrome-radius');
 }
 
@@ -916,9 +920,10 @@ const DesktopNav: React.FC<{
   const readingModeEnabled = showDocActions;
   const isDocsPage         = Boolean(currentDocSlug);
   const chromeGap          = isDocsPage ? DOC_CHROME_GAP : 0;
+  const chromeTopGap       = isDocsPage ? DOC_CHROME_TOP_GAP : 0;
   const chromeRadius       = isDocsPage ? DOC_CHROME_RADIUS : 0;
   const sidebarBg          = isDark ? 'rgba(15,15,15,0.84)' : 'rgba(224,223,219,0.82)';
-  const panelBg            = isDark ? 'rgba(15,15,15,0.78)' : 'rgba(224,223,219,0.78)';
+  const panelBg            = sidebarBg;
   const isStandardMode     = readingModeEnabled && readingMode === 'standard';
   const panelOpen          = isStandardMode ? (railVisible && standardSidebarOpen) : !!activePanel;
   const sidebarShellWidth  = RAIL_W + (panelOpen ? panelWidth : 0);
@@ -958,8 +963,8 @@ const DesktopNav: React.FC<{
         <div
           aria-hidden
           style={{
-            position: 'fixed', left: chromeGap, top: chromeGap, height: `calc(100vh - ${chromeGap * 2}px)`, width: sidebarShellWidth,
-            background: sidebarBg, border: `1px solid ${t.border}`, borderRadius: chromeRadius, zIndex: 47,
+            position: 'fixed', left: chromeGap, top: chromeTopGap, height: `calc(100vh - ${chromeTopGap + chromeGap}px)`, width: sidebarShellWidth,
+            background: sidebarBg, border: 'none', borderRadius: chromeRadius, zIndex: 47,
             pointerEvents: 'none', backdropFilter: 'blur(14px)', WebkitBackdropFilter: 'blur(14px)',
           }}
         />
@@ -967,14 +972,14 @@ const DesktopNav: React.FC<{
 
       {railVisible && (
         <aside style={{
-          position: 'fixed', left: chromeGap, top: chromeGap, height: isDocsPage ? `calc(100vh - ${chromeGap * 2}px)` : '100vh', width: RAIL_W,
+          position: 'fixed', left: chromeGap, top: chromeTopGap, height: isDocsPage ? `calc(100vh - ${chromeTopGap + chromeGap}px)` : '100vh', width: RAIL_W,
           background: isDocsPage ? 'transparent' : sidebarBg,
           border: isDocsPage ? 'none' : `1px solid ${t.border}`,
-          borderRight: panelOpen ? `1px solid ${t.border}` : 'none',
+          borderRight: 'none',
           borderRadius: panelOpen ? `${chromeRadius}px 0 0 ${chromeRadius}px` : chromeRadius,
           display: 'flex', flexDirection: 'column', alignItems: 'center',
           zIndex: 50, padding: '8px 0', gap: '2px',
-          backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)',
+          backdropFilter: isDocsPage ? 'none' : 'blur(12px)', WebkitBackdropFilter: isDocsPage ? 'none' : 'blur(12px)',
         }}>
           <div style={{ width: RAIL_W, height: 48, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
             <BrandLogo logoPath={logoPath} size={28} />
@@ -1024,7 +1029,7 @@ const DesktopNav: React.FC<{
 
       {!railVisible && (
         <button onClick={() => setRailVisible(true)}
-          style={{ position: 'fixed', left: chromeGap + 8, top: chromeGap + 8, zIndex: 55, display: 'flex', alignItems: 'center', justifyContent: 'center', width: 30, height: 30, borderRadius: '8px', border: `1px solid ${t.border}`, background: t.railBg, color: t.fgMuted, cursor: 'pointer' }}
+          style={{ position: 'fixed', left: chromeGap + 8, top: chromeTopGap + 8, zIndex: 55, display: 'flex', alignItems: 'center', justifyContent: 'center', width: 30, height: 30, borderRadius: '8px', border: `1px solid ${t.border}`, background: t.railBg, color: t.fgMuted, cursor: 'pointer' }}
           title="Показать">
           <PanelLeft size={14} />
         </button>
@@ -1032,7 +1037,7 @@ const DesktopNav: React.FC<{
 
       {railVisible && (
         <aside style={{
-          position: 'fixed', left: chromeGap + RAIL_W, top: chromeGap, height: isDocsPage ? `calc(100vh - ${chromeGap * 2}px)` : '100vh',
+          position: 'fixed', left: chromeGap + RAIL_W, top: chromeTopGap, height: isDocsPage ? `calc(100vh - ${chromeTopGap + chromeGap}px)` : '100vh',
           width: panelOpen ? panelWidth : 0,
           background: isDocsPage ? 'transparent' : panelBg,
           border: isDocsPage ? 'none' : panelOpen ? `1px solid ${t.border}` : 'none',
@@ -1040,7 +1045,7 @@ const DesktopNav: React.FC<{
           borderRadius: panelOpen ? `0 ${chromeRadius}px ${chromeRadius}px 0` : 0,
           display: 'flex', flexDirection: 'column', zIndex: 49, overflow: 'hidden',
           pointerEvents: panelOpen ? 'auto' : 'none', visibility: panelOpen ? 'visible' : 'hidden',
-          backdropFilter: 'blur(14px)', WebkitBackdropFilter: 'blur(14px)',
+          backdropFilter: isDocsPage ? 'none' : 'blur(14px)', WebkitBackdropFilter: isDocsPage ? 'none' : 'blur(14px)',
         }}>
           {panelOpen && (
             <>
@@ -1068,16 +1073,16 @@ const DesktopNav: React.FC<{
 
       {isStandardMode && standardTocVisible && (
         <aside style={{
-          position: 'fixed', right: chromeGap, top: chromeGap, width: TOC_PANEL_W, height: isDocsPage ? `calc(100vh - ${chromeGap * 2}px)` : '100vh',
-          border: isDocsPage ? `1px solid ${t.border}` : 'none',
-          borderLeft: `1px solid ${t.border}`,
+          position: 'fixed', right: chromeGap, top: chromeTopGap, width: TOC_PANEL_W, height: isDocsPage ? `calc(100vh - ${chromeTopGap + chromeGap}px)` : '100vh',
+          border: 'none',
+          borderLeft: 'none',
           borderRadius: `${chromeRadius}px 0 0 ${chromeRadius}px`,
           overflow: 'hidden',
           background: panelBg,
           zIndex: 48, display: 'flex', flexDirection: 'column',
           backdropFilter: 'blur(14px)', WebkitBackdropFilter: 'blur(14px)',
         }}>
-          <div style={{ borderBottom: `1px solid ${t.border}`, padding: '10px 12px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ borderBottom: 'none', padding: '10px 12px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <span style={{ fontSize: '0.72rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', color: t.fgMuted }}>Оглавление</span>
             <div style={{ display: 'flex', gap: '6px' }}>
               <button
@@ -1106,7 +1111,7 @@ const DesktopNav: React.FC<{
         <button
           onClick={() => setStandardTocVisible(true)}
           style={{
-            position: 'fixed', right: chromeGap + 12, top: chromeGap + 12, zIndex: 56, border: `1px solid ${t.border}`, borderRadius: '8px',
+            position: 'fixed', right: chromeGap + 12, top: chromeTopGap + 12, zIndex: 56, border: `1px solid ${t.border}`, borderRadius: '8px',
             background: t.panelBg, color: t.fgMuted, padding: '6px 8px', cursor: 'pointer', fontSize: '0.75rem',
           }}
         >

--- a/src/features/navigation/components/Navigation.tsx
+++ b/src/features/navigation/components/Navigation.tsx
@@ -32,6 +32,8 @@ const PANEL_DEFAULT = 280;
 const PANEL_MIN     = 220;
 const PANEL_MAX     = 500;
 const TOC_PANEL_W   = 300;
+const DOC_CHROME_GAP = 10;
+const DOC_CHROME_RADIUS = 18;
 
 export interface TocItem { id: string; text: string; level: number; }
 interface CategoryPathItem { slug: string; title: string; icon: string | null; }
@@ -836,20 +838,26 @@ function buildCssVars(
   isStandardMode: boolean,
   standardTocVisible: boolean,
 ): void {
+  const chromeGap     = isDocsPage ? DOC_CHROME_GAP : 0;
   const panelOffset   = isDocsPage && panelOpen ? panelWidth : 0;
-  const left          = railVisible ? RAIL_W + panelOffset : 0;
+  const left          = railVisible ? chromeGap + RAIL_W + panelOffset + chromeGap : chromeGap;
+  const docRight      = isDocsPage && isStandardMode && standardTocVisible ? chromeGap + TOC_PANEL_W + chromeGap : chromeGap;
   const sidebarHidden = isDocsPage && isStandardMode && !railVisible;
   const tocHidden     = isDocsPage && isStandardMode && !standardTocVisible;
   document.documentElement.style.setProperty('--nav-left', `${left}px`);
-  document.documentElement.style.setProperty('--doc-right', isDocsPage && isStandardMode && standardTocVisible ? `${TOC_PANEL_W}px` : '0px');
+  document.documentElement.style.setProperty('--doc-right', `${docRight}px`);
   document.documentElement.style.setProperty('--doc-border-left', sidebarHidden ? '1' : '0');
   document.documentElement.style.setProperty('--doc-border-right', tocHidden ? '1' : '0');
+  document.documentElement.style.setProperty('--doc-chrome-gap', `${chromeGap}px`);
+  document.documentElement.style.setProperty('--doc-chrome-radius', `${isDocsPage ? DOC_CHROME_RADIUS : 0}px`);
 }
 
 function clearDocCssVars(): void {
   document.documentElement.style.removeProperty('--doc-right');
   document.documentElement.style.removeProperty('--doc-border-left');
   document.documentElement.style.removeProperty('--doc-border-right');
+  document.documentElement.style.removeProperty('--doc-chrome-gap');
+  document.documentElement.style.removeProperty('--doc-chrome-radius');
 }
 
 function getReadingModeFromStorage(): ReadingMode {
@@ -906,11 +914,17 @@ const DesktopNav: React.FC<{
   const { activePanel, setActivePanel, panelWidth, setPanelWidth, togglePanel } = useDesktopPanel();
   const { onResizeMouseDown } = usePanelResize(panelWidth, setPanelWidth);
   const readingModeEnabled = showDocActions;
+  const isDocsPage         = Boolean(currentDocSlug);
+  const chromeGap          = isDocsPage ? DOC_CHROME_GAP : 0;
+  const chromeRadius       = isDocsPage ? DOC_CHROME_RADIUS : 0;
+  const sidebarBg          = isDark ? 'rgba(15,15,15,0.84)' : 'rgba(224,223,219,0.82)';
+  const panelBg            = isDark ? 'rgba(15,15,15,0.78)' : 'rgba(224,223,219,0.78)';
   const isStandardMode     = readingModeEnabled && readingMode === 'standard';
   const panelOpen          = isStandardMode ? (railVisible && standardSidebarOpen) : !!activePanel;
+  const sidebarShellWidth  = RAIL_W + (panelOpen ? panelWidth : 0);
 
   // Текущий тип активной панели — всегда строка, не null
-  const panelTitle: Exclude<PanelType, null> = activePanel ?? 'nav';
+  const panelTitle: Exclude<PanelType, null> = isStandardMode ? 'nav' : activePanel ?? 'nav';
 
   const handleTogglePanel = useCallback((panel: Exclude<PanelType, null>) => {
     if (isStandardMode) {
@@ -930,10 +944,9 @@ const DesktopNav: React.FC<{
   }, [standardTocVisible]);
 
   useEffect(() => {
-    const isDocsPage = Boolean(currentDocSlug);
     buildCssVars(railVisible, isDocsPage, panelOpen, panelWidth, isStandardMode, standardTocVisible);
     return () => { document.documentElement.style.removeProperty('--nav-left'); };
-  }, [railVisible, panelOpen, panelWidth, isStandardMode, standardTocVisible, currentDocSlug]);
+  }, [railVisible, panelOpen, panelWidth, isStandardMode, standardTocVisible, isDocsPage]);
 
   useEffect(() => {
     return clearDocCssVars;
@@ -941,11 +954,24 @@ const DesktopNav: React.FC<{
 
   return (
     <>
+      {railVisible && isDocsPage && (
+        <div
+          aria-hidden
+          style={{
+            position: 'fixed', left: chromeGap, top: chromeGap, height: `calc(100vh - ${chromeGap * 2}px)`, width: sidebarShellWidth,
+            background: sidebarBg, border: `1px solid ${t.border}`, borderRadius: chromeRadius, zIndex: 47,
+            pointerEvents: 'none', backdropFilter: 'blur(14px)', WebkitBackdropFilter: 'blur(14px)',
+          }}
+        />
+      )}
+
       {railVisible && (
         <aside style={{
-          position: 'fixed', left: 0, top: 0, height: '100vh', width: RAIL_W,
-          background: isDark ? 'rgba(15,15,15,0.84)' : 'rgba(224,223,219,0.82)',
-          borderRight: `1px solid ${t.border}`,
+          position: 'fixed', left: chromeGap, top: chromeGap, height: isDocsPage ? `calc(100vh - ${chromeGap * 2}px)` : '100vh', width: RAIL_W,
+          background: isDocsPage ? 'transparent' : sidebarBg,
+          border: isDocsPage ? 'none' : `1px solid ${t.border}`,
+          borderRight: panelOpen ? `1px solid ${t.border}` : 'none',
+          borderRadius: panelOpen ? `${chromeRadius}px 0 0 ${chromeRadius}px` : chromeRadius,
           display: 'flex', flexDirection: 'column', alignItems: 'center',
           zIndex: 50, padding: '8px 0', gap: '2px',
           backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)',
@@ -970,8 +996,8 @@ const DesktopNav: React.FC<{
                 />
                 {readingModeMenuOpen && (
                   <div style={{
-                    position: 'absolute', left: '100%', top: 0, marginLeft: '8px', width: '190px', padding: '8px',
-                    borderRadius: '10px', border: `1px solid ${t.border}`, background: t.panelBg, boxShadow: 'none', zIndex: 70,
+                    position: 'absolute', left: 'calc(100% - 1px)', top: 0, marginLeft: 0, width: '190px', padding: '8px',
+                    borderRadius: `0 ${chromeRadius || 10}px ${chromeRadius || 10}px 0`, border: `1px solid ${t.border}`, borderLeft: 'none', background: sidebarBg, boxShadow: 'none', zIndex: 70,
                   }}>
                     <button onClick={() => { setReadingMode('standard'); setReadingModeMenuOpen(false); }}
                       style={{ width: '100%', textAlign: 'left', border: 'none', borderRadius: '8px', padding: '8px 10px', cursor: 'pointer', background: readingMode === 'standard' ? t.accentSoft : 'transparent', color: t.fg, fontSize: '0.8rem' }}>
@@ -998,7 +1024,7 @@ const DesktopNav: React.FC<{
 
       {!railVisible && (
         <button onClick={() => setRailVisible(true)}
-          style={{ position: 'fixed', left: 8, top: 8, zIndex: 55, display: 'flex', alignItems: 'center', justifyContent: 'center', width: 30, height: 30, borderRadius: '8px', border: `1px solid ${t.border}`, background: t.railBg, color: t.fgMuted, cursor: 'pointer' }}
+          style={{ position: 'fixed', left: chromeGap + 8, top: chromeGap + 8, zIndex: 55, display: 'flex', alignItems: 'center', justifyContent: 'center', width: 30, height: 30, borderRadius: '8px', border: `1px solid ${t.border}`, background: t.railBg, color: t.fgMuted, cursor: 'pointer' }}
           title="Показать">
           <PanelLeft size={14} />
         </button>
@@ -1006,10 +1032,12 @@ const DesktopNav: React.FC<{
 
       {railVisible && (
         <aside style={{
-          position: 'fixed', left: RAIL_W, top: 0, height: '100vh',
+          position: 'fixed', left: chromeGap + RAIL_W, top: chromeGap, height: isDocsPage ? `calc(100vh - ${chromeGap * 2}px)` : '100vh',
           width: panelOpen ? panelWidth : 0,
-          background: isDark ? 'rgba(15,15,15,0.78)' : 'rgba(224,223,219,0.78)',
-          borderRight: panelOpen ? `1px solid ${t.border}` : 'none',
+          background: isDocsPage ? 'transparent' : panelBg,
+          border: isDocsPage ? 'none' : panelOpen ? `1px solid ${t.border}` : 'none',
+          borderLeft: 'none',
+          borderRadius: panelOpen ? `0 ${chromeRadius}px ${chromeRadius}px 0` : 0,
           display: 'flex', flexDirection: 'column', zIndex: 49, overflow: 'hidden',
           pointerEvents: panelOpen ? 'auto' : 'none', visibility: panelOpen ? 'visible' : 'hidden',
           backdropFilter: 'blur(14px)', WebkitBackdropFilter: 'blur(14px)',
@@ -1040,9 +1068,12 @@ const DesktopNav: React.FC<{
 
       {isStandardMode && standardTocVisible && (
         <aside style={{
-          position: 'fixed', right: 0, top: 0, width: TOC_PANEL_W, height: '100vh',
+          position: 'fixed', right: chromeGap, top: chromeGap, width: TOC_PANEL_W, height: isDocsPage ? `calc(100vh - ${chromeGap * 2}px)` : '100vh',
+          border: isDocsPage ? `1px solid ${t.border}` : 'none',
           borderLeft: `1px solid ${t.border}`,
-          background: isDark ? 'rgba(15,15,15,0.78)' : 'rgba(224,223,219,0.78)',
+          borderRadius: `${chromeRadius}px 0 0 ${chromeRadius}px`,
+          overflow: 'hidden',
+          background: panelBg,
           zIndex: 48, display: 'flex', flexDirection: 'column',
           backdropFilter: 'blur(14px)', WebkitBackdropFilter: 'blur(14px)',
         }}>
@@ -1075,7 +1106,7 @@ const DesktopNav: React.FC<{
         <button
           onClick={() => setStandardTocVisible(true)}
           style={{
-            position: 'fixed', right: 12, top: 12, zIndex: 56, border: `1px solid ${t.border}`, borderRadius: '8px',
+            position: 'fixed', right: chromeGap + 12, top: chromeGap + 12, zIndex: 56, border: `1px solid ${t.border}`, borderRadius: '8px',
             background: t.panelBg, color: t.fgMuted, padding: '6px 8px', cursor: 'pointer', fontSize: '0.75rem',
           }}
         >


### PR DESCRIPTION
### Motivation
- Create a visual "chrome" around the docs content on desktop to separate the document area from the navigation/panel rails and enable rounded corners and backdrop styling.

### Description
- Add `DOC_CHROME_GAP` and `DOC_CHROME_RADIUS` constants and expose `--doc-chrome-gap` and `--doc-chrome-radius` CSS variables from `buildCssVars` and remove them in `clearDocCssVars`.
- Read `--doc-chrome-gap` and `--doc-chrome-radius` in `DocContentMain` and apply them to the main article container via state (`docChromeGap` and `docChromeRadius`) to control margins, border, radius, shadow, and overflow on desktop.
- Update `DesktopNav` layout to account for the chrome gap and radius by offsetting rail/panel positions, rendering a rounded blurred sidebar shell, and adjusting panel/TOC positions and border styles using `chromeGap`/`chromeRadius`.
- Ensure responsive behavior by defaulting chrome gap and radius to `0px` when not on desktop.

### Testing
- Performed a local TypeScript typecheck and development build with `yarn build` which completed successfully.
- Ran the linter with `yarn lint` and no new issues were reported.
- Executed the project's test suite with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb178bd364832e9e07a6f16e784a2e)