### PR TITLE
Add static fallbacks for slow hydration

### DIFF
--- a/src/app/layouts/Layout.astro
+++ b/src/app/layouts/Layout.astro
@@ -135,7 +135,8 @@ const articleJsonLd = type === 'article' ? JSON.stringify({
     <!-- Theme: runs before paint, prevents flash -->
     <script is:inline>
       (function () {
-        var t = localStorage.getItem('theme') || 'dark';
+        var t = 'dark';
+        try { t = localStorage.getItem('theme') || 'dark'; } catch (e) {}
         var d = t !== 'light';
         document.documentElement.classList.toggle('dark', d);
         document.documentElement.style.colorScheme = d ? 'dark' : 'light';
@@ -222,6 +223,41 @@ const articleJsonLd = type === 'article' ? JSON.stringify({
       html.dark        { background-color: #0a0a0a; }
       body { margin: 0; padding: 0; overflow-x: hidden; }
 
+      .ssg-hydration-fallback {
+        min-height: 100vh;
+        background: #E8E7E3;
+        color: #111111;
+      }
+      html.dark .ssg-hydration-fallback {
+        background: #0a0a0a;
+        color: #f5f5f5;
+      }
+      html.app-hydrated .ssg-hydration-fallback { display: none !important; }
+      .ssg-fallback-shell {
+        width: min(100%, 980px);
+        margin: 0 auto;
+        padding: clamp(1.5rem, 5vw, 4rem) 1rem;
+      }
+      .ssg-fallback-shell h1 {
+        margin: 0 0 1rem;
+        font-size: clamp(2rem, 8vw, 4.5rem);
+        line-height: 1;
+        letter-spacing: -0.06em;
+      }
+      .ssg-fallback-shell h2 {
+        margin: 2rem 0 0.75rem;
+        font-size: clamp(1.25rem, 4vw, 2rem);
+      }
+      .ssg-fallback-shell p,
+      .ssg-fallback-shell li {
+        color: rgba(17, 17, 17, 0.78);
+        line-height: 1.7;
+      }
+      html.dark .ssg-fallback-shell p,
+      html.dark .ssg-fallback-shell li { color: rgba(245, 245, 245, 0.78); }
+      .ssg-fallback-shell a { color: inherit; }
+      .ssg-fallback-muted { opacity: 0.72; }
+
       /* Скрытый SEO-контент — видим для ботов, невидим для пользователей */
       #seo-landing-content {
         position: absolute;
@@ -247,7 +283,8 @@ const articleJsonLd = type === 'article' ? JSON.stringify({
     <!-- Re-apply theme after SPA navigation -->
     <script is:inline>
       document.addEventListener('astro:after-swap', function () {
-        var t = localStorage.getItem('theme') || 'dark';
+        var t = 'dark';
+        try { t = localStorage.getItem('theme') || 'dark'; } catch (e) {}
         var d = t !== 'light';
         document.documentElement.classList.toggle('dark', d);
         document.documentElement.style.colorScheme = d ? 'dark' : 'light';

--- a/src/app/pages/404.astro
+++ b/src/app/pages/404.astro
@@ -9,5 +9,12 @@ import NotFound from '@/shared/components/NotFound';
   url="/404"
   robots="noindex, nofollow"
 >
+  <section class="ssg-hydration-fallback" aria-label="Статическая версия страницы 404">
+    <div class="ssg-fallback-shell" style="text-align:center;">
+      <h1>404</h1>
+      <p>Страница не найдена. Интерактивная версия загрузится автоматически, когда браузер получит JavaScript.</p>
+      <p><a href="/">Вернуться на главную</a></p>
+    </div>
+  </section>
   <NotFound client:only="react" />
 </Layout>

--- a/src/app/pages/[...slug].astro
+++ b/src/app/pages/[...slug].astro
@@ -66,10 +66,13 @@ if (!doc || !slug) return Astro.redirect('/404');
   robots={doc.robots}
   lang={doc.lang || 'ru'}
 >
-  <noscript>
-    <main style="max-width: 980px; margin: 0 auto; padding: 2rem 1rem;">
-      <article set:html={doc.content ?? ''} />
-    </main>
-  </noscript>
+  <section class="ssg-hydration-fallback" aria-label="Статическая версия документа">
+    <article class="ssg-fallback-shell">
+      <p class="ssg-fallback-muted">Загружаем интерактивную версию страницы…</p>
+      <h1>{doc.title}</h1>
+      {doc.description && <p>{doc.description}</p>}
+      <div set:html={doc.content ?? ''} />
+    </article>
+  </section>
   <DocContent client:only="react" doc={doc} />
 </Layout>

--- a/src/app/pages/index.astro
+++ b/src/app/pages/index.astro
@@ -127,10 +127,34 @@ const lang        = useLanding ? 'ru' : (welcomeDoc?.lang || 'ru');
         </section>
       </article>
 
+      <section class="ssg-hydration-fallback" aria-label="Статическая версия главной страницы">
+        <div class="ssg-fallback-shell">
+          <p class="ssg-fallback-muted">Загружаем интерактивную версию сайта…</p>
+          <h1>Opensophy</h1>
+          <p>{LANDING_DESCRIPTION}</p>
+          <h2>Безопасность прежде всего</h2>
+          <p>Интеграция SAST, DAST, SCA — автоматический анализ кода на уязвимости на каждом этапе разработки.</p>
+          <h2>Экосистема для разработчиков</h2>
+          <ul>
+            <li>Туториалы по кибербезопасности и DevSecOps</li>
+            <li>Open-source инструменты для разработчиков</li>
+            <li>Материалы по Linux, Docker, CI/CD и инфраструктуре</li>
+            <li>UI библиотека с готовыми компонентами и живым превью</li>
+          </ul>
+          <h2>Контакты</h2>
+          <p>GitHub: github.com/opensophy-projects · Habr: habr.com/ru/users/opensophy/ · Email: opensophy@gmail.com</p>
+        </div>
+      </section>
+
       <GeneralPageWrapper client:only="react" />
     </>
   ) : welcomeDoc ? (
-    <DocContent client:only="react" doc={welcomeDoc} />
+    <>
+      <section class="ssg-hydration-fallback" aria-label="Статическая версия документа">
+        <article class="ssg-fallback-shell" set:html={welcomeDoc.content ?? ''} />
+      </section>
+      <DocContent client:only="react" doc={welcomeDoc} />
+    </>
   ) : (
     <div style="min-height:100vh;display:flex;align-items:center;justify-content:center;">
       <p>Загрузка...</p>

--- a/src/features/docs/components/DocContent.tsx
+++ b/src/features/docs/components/DocContent.tsx
@@ -172,6 +172,10 @@ const DocHero: React.FC<DocHeroProps> = ({ doc, isDark, readTime, liveFM, showDo
 // ─── DocContent ───────────────────────────────────────────────────────────────
 
 const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
+  useEffect(() => {
+    document.documentElement.classList.add('app-hydrated');
+  }, []);
+
   const { isDark } = useTheme();
   const t = makeTokens(isDark);
   const [fullscreenTableHtml, setFullscreenTableHtml] = useState<string | null>(null);

--- a/src/features/general/components/GeneralPageWrapper.tsx
+++ b/src/features/general/components/GeneralPageWrapper.tsx
@@ -8,5 +8,13 @@
  *
  * Must be used with client:only="react" in Astro.
  */
+import { useEffect } from 'react';
 import GeneralPage from './GeneralPage';
-export default GeneralPage;
+
+export default function GeneralPageWrapper() {
+  useEffect(() => {
+    document.documentElement.classList.add('app-hydrated');
+  }, []);
+
+  return <GeneralPage />;
+}

--- a/src/shared/components/NotFound.tsx
+++ b/src/shared/components/NotFound.tsx
@@ -5,6 +5,10 @@ import { makeTokens } from '@/shared/tokens/theme';
 
 // ThemeProvider обязателен — island изолирован от контекста Layout.astro
 const NotFoundContent: React.FC = () => {
+  useEffect(() => {
+    document.documentElement.classList.add('app-hydrated');
+  }, []);
+
   const { isDark } = useTheme();
   const tokens = makeTokens(isDark);
   const [countdown, setCountdown] = useState(10);


### PR DESCRIPTION
### Motivation
- Pages that are rendered as React islands could show a blank (theme-colored) screen on slow connections because interactive bundles arrive late. 
- Provide immediate readable content by showing server-rendered static fallbacks until the React islands mount and hydrate. 
- Make early theme bootstrapping resilient to `localStorage` access failures so the inline theme script cannot throw and the fallback visuals match the theme.

### Description
- Add visible SSG fallback markup for the landing page (`src/app/pages/index.astro`), article pages (`src/app/pages/[...slug].astro`) and the 404 page (`src/app/pages/404.astro`) so users see content while JS loads. 
- Add global styles for `.ssg-hydration-fallback` / `.ssg-fallback-shell` in `src/app/layouts/Layout.astro` and hide these fallbacks only after a mount marker class `app-hydrated` is applied. 
- Apply `app-hydrated` from the relevant React islands by adding `useEffect` hooks in `src/features/docs/components/DocContent.tsx`, `src/features/general/components/GeneralPageWrapper.tsx` and `src/shared/components/NotFound.tsx`. 
- Harden theme bootstrap and re-apply scripts in `src/app/layouts/Layout.astro` to `try/catch` `localStorage` reads so the inline scripts are safe on restricted environments.

### Testing
- `npm run build` completed successfully and produced the static output (Astro build succeeded). 
- `npm run lint` exited with failures due to pre-existing lint issues in other source files (ESLint reported multiple errors/warnings), so lint did not pass end-to-end.
- Manual network testing recommendation: simulate `Slow 3G` in DevTools with cache disabled and verify the static fallback is visible until interactive UI hydrates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7548268c832ebd529d2eb8ddf296)