### PR TITLE
feat(ui): add toggle button to show source in UI Component Viewer

### DIFF
--- a/src/features/ui-components/NewUIComponentViewer.tsx
+++ b/src/features/ui-components/NewUIComponentViewer.tsx
@@ -5,7 +5,7 @@ import { createPortal } from 'react-dom';
 import { useTheme } from '@/shared/contexts/ThemeContext';
 import {
   X, Minimize2, Play, RefreshCcw,
-  Settings, PanelRight, PanelRightClose, ChevronDown, MonitorSmartphone,
+  Settings, PanelRight, PanelRightClose, ChevronDown, MonitorSmartphone, Code2,
 } from 'lucide-react';
 import { loadComponent, getDefaultProps } from './loader';
 import { ComponentWrapper } from './ComponentWrapper';
@@ -648,7 +648,7 @@ const FullscreenModal: React.FC<ComponentRenderProps & { config: ComponentConfig
   );
 };
 
-const PreviewPanel: React.FC<ComponentRenderProps & { config: ComponentConfig; onRefresh: () => void; onFullscreen: () => void; onOpenSettings: () => void; t: T; loading: boolean; isMobile: boolean }> = ({ config, Component, componentProps, universalProps, refreshKey, isDark, componentCategory, onRefresh, onFullscreen, onOpenSettings, t, loading, isMobile }) => (
+const PreviewPanel: React.FC<ComponentRenderProps & { config: ComponentConfig; onRefresh: () => void; onFullscreen: () => void; onOpenSettings: () => void; onToggleSource: () => void; showSource: boolean; t: T; loading: boolean; isMobile: boolean }> = ({ config, Component, componentProps, universalProps, refreshKey, isDark, componentCategory, onRefresh, onFullscreen, onOpenSettings, onToggleSource, showSource, t, loading, isMobile }) => (
   <div style={{ borderRadius: 12, border: `1px solid ${t.outerBorder}`, background: t.outerBg, boxShadow: t.outerShadow, display: 'flex', flexDirection: 'column', width: '100%', minWidth: 0, overflow: 'hidden' }}>
     <div style={{ display: 'flex', alignItems: 'center', gap: isMobile ? 4 : 6, padding: isMobile ? '8px' : '8px 10px', borderBottom: `1px solid ${t.barBorder}`, background: t.barBg, flexWrap: 'nowrap', minWidth: 0 }}>
       {!isMobile && <div style={{ fontSize: 13, fontWeight: 600, color: t.fgMuted, padding: '3px 9px', borderRadius: 7, background: t.btnBg, border: `1px solid ${t.barBorder}`, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 200, flexShrink: 1 }}>{config.name}</div>}
@@ -656,6 +656,7 @@ const PreviewPanel: React.FC<ComponentRenderProps & { config: ComponentConfig; o
       <Pill onClick={onRefresh}      title="Перезапустить" label=""     icon={<Play      size={14} />} t={t} compact={isMobile} />
       <Pill onClick={onFullscreen}   title="Развернуть"    label=""      icon={<MonitorSmartphone size={14} />} t={t} compact={isMobile} />
       <Pill onClick={onOpenSettings} title="Настройки"     label=""   icon={<Settings  size={14} />} t={t} compact={isMobile} />
+      <Pill onClick={onToggleSource} title="Показать исходный код" label="" icon={<Code2 size={14} />} t={t} compact={isMobile} active={showSource} />
     </div>
 
     {/* Область предпросмотра фиксированной высоты без прыжков */}
@@ -766,6 +767,7 @@ const UIComponentViewer: React.FC<{ componentId: string }> = ({ componentId }) =
   const [universalProps, setUniversalProps] = useState<UniversalProps>(DEFAULT_UNIVERSAL_PROPS);
   const [componentData,  setComponentData]  = useState<LoadedComponentData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [showSource, setShowSource] = useState(false);
 
   useEffect(() => {
     setLoading(true);
@@ -837,12 +839,14 @@ const UIComponentViewer: React.FC<{ componentId: string }> = ({ componentId }) =
           onRefresh={handleRefresh}
           onFullscreen={() => setIsFullscreen(true)}
           onOpenSettings={() => setSettingsOpen(true)}
+          onToggleSource={() => setShowSource(v => !v)}
+          showSource={showSource}
           t={t}
           loading={loading}
           isMobile={isMobile}
         />
       )}
-      <SourceCodePanel fileContents={effectiveData.fileContents} t={t} />
+      {showSource && <SourceCodePanel fileContents={effectiveData.fileContents} t={t} />}
       {isFullscreen && componentData && (
         <FullscreenModal
           {...shared}

--- a/src/features/ui-components/NewUIComponentViewer.tsx
+++ b/src/features/ui-components/NewUIComponentViewer.tsx
@@ -648,7 +648,7 @@ const FullscreenModal: React.FC<ComponentRenderProps & { config: ComponentConfig
   );
 };
 
-const PreviewPanel: React.FC<ComponentRenderProps & { config: ComponentConfig; onRefresh: () => void; onFullscreen: () => void; onOpenSettings: () => void; onToggleSource: () => void; showSource: boolean; t: T; loading: boolean; isMobile: boolean }> = ({ config, Component, componentProps, universalProps, refreshKey, isDark, componentCategory, onRefresh, onFullscreen, onOpenSettings, onToggleSource, showSource, t, loading, isMobile }) => (
+const PreviewPanel: React.FC<ComponentRenderProps & { config: ComponentConfig; onRefresh: () => void; onFullscreen: () => void; onOpenSettings: () => void; onToggleSource: () => void; showSource: boolean; t: T; loading: boolean; isMobile: boolean }> = ({ config, Component, componentProps, universalProps, refreshKey, isDark, componentCategory, fileContents, onRefresh, onFullscreen, onOpenSettings, onToggleSource, showSource, t, loading, isMobile }) => (
   <div style={{ borderRadius: 12, border: `1px solid ${t.outerBorder}`, background: t.outerBg, boxShadow: t.outerShadow, display: 'flex', flexDirection: 'column', width: '100%', minWidth: 0, overflow: 'hidden' }}>
     <div style={{ display: 'flex', alignItems: 'center', gap: isMobile ? 4 : 6, padding: isMobile ? '8px' : '8px 10px', borderBottom: `1px solid ${t.barBorder}`, background: t.barBg, flexWrap: 'nowrap', minWidth: 0 }}>
       {!isMobile && <div style={{ fontSize: 13, fontWeight: 600, color: t.fgMuted, padding: '3px 9px', borderRadius: 7, background: t.btnBg, border: `1px solid ${t.barBorder}`, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 200, flexShrink: 1 }}>{config.name}</div>}
@@ -674,7 +674,7 @@ const PreviewPanel: React.FC<ComponentRenderProps & { config: ComponentConfig; o
           Загрузка компонента…
         </div>
       )}
-      {!loading && (
+      {!loading && !showSource && (
         <ComponentRender
           Component={Component}
           componentProps={componentProps}
@@ -684,6 +684,7 @@ const PreviewPanel: React.FC<ComponentRenderProps & { config: ComponentConfig; o
           componentCategory={componentCategory}
         />
       )}
+      {!loading && showSource && <SourceCodePanel fileContents={fileContents} t={t} maxHeight="100%" bordered={false} />}
     </div>
 
     <div style={{ padding: '6px 12px', borderTop: `1px solid ${t.barBorder}`, fontSize: 11, color: t.footerClr, display: 'flex', alignItems: 'center', justifyContent: 'space-between', userSelect: 'none', background: t.outerBg, flexShrink: 0 }}>
@@ -714,7 +715,7 @@ const SettingsPanel: React.FC<ComponentRenderProps & { config: ComponentConfig; 
 
 
 
-const SourceCodePanel: React.FC<{ fileContents: Record<string, string>; t: T }> = ({ fileContents, t }) => {
+const SourceCodePanel: React.FC<{ fileContents: Record<string, string>; t: T; maxHeight?: number | string; bordered?: boolean }> = ({ fileContents, t, maxHeight = 320, bordered = true }) => {
   const files = Object.entries(fileContents);
   const [activeFile, setActiveFile] = useState(files[0]?.[0] ?? '');
 
@@ -729,7 +730,7 @@ const SourceCodePanel: React.FC<{ fileContents: Record<string, string>; t: T }> 
   }
 
   return (
-    <div style={{ borderTop: `1px solid ${t.barBorder}`, background: t.outerBg }}>
+    <div style={{ borderTop: bordered ? `1px solid ${t.barBorder}` : 'none', background: t.outerBg, width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
       <div style={{ display: 'flex', gap: 6, padding: '8px 10px', borderBottom: `1px solid ${t.barBorder}`, flexWrap: 'wrap' }}>
         {files.map(([name]) => {
           const isActive = name === activeFile;
@@ -740,7 +741,7 @@ const SourceCodePanel: React.FC<{ fileContents: Record<string, string>; t: T }> 
           );
         })}
       </div>
-      <pre style={{ margin: 0, padding: 12, maxHeight: 320, overflow: 'auto', fontSize: 12, lineHeight: 1.45, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace', color: t.fg, background: t.panelBg }}>
+      <pre style={{ margin: 0, padding: 12, maxHeight, overflow: 'auto', fontSize: 12, lineHeight: 1.45, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace', color: t.fg, background: t.panelBg, flex: 1 }}>
         <code>{activeCode}</code>
       </pre>
     </div>
@@ -846,7 +847,6 @@ const UIComponentViewer: React.FC<{ componentId: string }> = ({ componentId }) =
           isMobile={isMobile}
         />
       )}
-      {showSource && <SourceCodePanel fileContents={effectiveData.fileContents} t={t} />}
       {isFullscreen && componentData && (
         <FullscreenModal
           {...shared}

--- a/src/features/ui-components/loader.ts
+++ b/src/features/ui-components/loader.ts
@@ -1,7 +1,7 @@
 import { registry } from './registry';
-import type { ComponentConfig, LoadedComponent } from '../types';
+import type { ComponentConfig, LoadedComponent } from './types';
 
-const sourceModules = import.meta.glob('../*/*.tsx', { query: '?raw', import: 'default' });
+const sourceModules = import.meta.glob('./*/*.tsx', { query: '?raw', import: 'default' });
 
 type PropValue = string | number | boolean | string[] | undefined;
 
@@ -15,13 +15,13 @@ function pickMainSourcePath(componentId: string, config: ComponentConfig): strin
   const mainFile = (config as ComponentConfig & { main?: string }).main;
 
   const preferred = [
-    mainFile && `../${componentId}/${mainFile}`,
-    `../${componentId}/${componentId}.tsx`,
-    `../${componentId}/index.tsx`,
-    `../${componentId}/index.ts`,
+    mainFile && `./${componentId}/${mainFile}`,
+    `./${componentId}/${componentId}.tsx`,
+    `./${componentId}/index.tsx`,
+    `./${componentId}/index.ts`,
   ].filter((p): p is string => !!p && !p.endsWith('undefined'));
 
-  const allTsx = Object.keys(sourceModules).filter(k => k.startsWith(`../${componentId}/`));
+  const allTsx = Object.keys(sourceModules).filter(k => k.startsWith(`./${componentId}/`));
   const candidates = [...new Set([...preferred, ...allTsx])];
 
   for (const candidate of candidates) {

--- a/src/features/ui-components/loader.ts
+++ b/src/features/ui-components/loader.ts
@@ -1,7 +1,7 @@
 import { registry } from './registry';
 import type { ComponentConfig, LoadedComponent } from './types';
 
-const sourceModules = import.meta.glob('./*/*.tsx', { query: '?raw', import: 'default' });
+const sourceModules = import.meta.glob('./*/*.tsx', { eager: true, query: '?raw', import: 'default' });
 
 type PropValue = string | number | boolean | string[] | undefined;
 
@@ -31,18 +31,36 @@ function pickMainSourcePath(componentId: string, config: ComponentConfig): strin
   return null;
 }
 
-async function loadFileContents(componentId: string, config: ComponentConfig): Promise<Record<string, string>> {
-  const sourcePath = pickMainSourcePath(componentId, config);
-  if (!sourcePath) return {};
+function resolveConfigFilePath(componentId: string, configPath: string): string | null {
+  if (configPath.startsWith('./') || configPath.startsWith('../')) return configPath;
+  if (configPath.startsWith(`${componentId}/`)) return `./${configPath}`;
+  return `./${componentId}/${configPath}`;
+}
 
-  try {
-    const source = await sourceModules[sourcePath]() as string;
+function loadFileContents(componentId: string, config: ComponentConfig): Record<string, string> {
+  const entries: Record<string, string> = {};
+  const requested = new Set<string>();
+
+  const mainPath = pickMainSourcePath(componentId, config);
+  if (mainPath) requested.add(mainPath);
+
+  config.files?.forEach((file) => {
+    if (file.path) requested.add(resolveConfigFilePath(componentId, file.path) ?? '');
+  });
+
+  Object.keys(sourceModules)
+    .filter((k) => k.startsWith(`./${componentId}/`))
+    .forEach((k) => requested.add(k));
+
+  for (const sourcePath of requested) {
+    if (!sourcePath) continue;
+    const source = sourceModules[sourcePath];
+    if (typeof source !== 'string') continue;
     const fileName = sourcePath.split('/').at(-1) ?? `${componentId}.tsx`;
-    return { [fileName]: source };
-  } catch (error) {
-    console.warn('[loader] Не удалось загрузить исходник компонента:', sourcePath, error);
-    return {};
+    entries[fileName] = source;
   }
+
+  return entries;
 }
 // ─── Внутренний загрузчик ─────────────────────────────────────────────────────
 async function loadComponentInternal(componentId: string): Promise<LoadedComponent | null> {
@@ -59,7 +77,7 @@ async function loadComponentInternal(componentId: string): Promise<LoadedCompone
       return null;
     }
 
-    const fileContents = await loadFileContents(componentId, config);
+    const fileContents = loadFileContents(componentId, config);
     return { config, Component, fileContents };
   } catch (error) {
     console.error('[loader] Ошибка при загрузке компонента:', componentId, error);


### PR DESCRIPTION
### Motivation
- Упростить просмотр исходного кода UI-компонентов прямо в `UIComponentViewer` без постоянного отображения панели кода.
- Дать пользователю возможность включать/выключать показ файла(ов) кода по кнопке в тулбаре предпросмотра.

### Description
- Добавлен импорт иконки `Code2` из `lucide-react` и новая кнопка в тулбаре превью для переключения просмотра кода (`PreviewPanel`).
- Прокинуто новое API в `PreviewPanel`: `onToggleSource` и `showSource` для управления состоянием отображения кода из родителя.
- В `UIComponentViewer` добавлено локальное состояние `showSource` и логика переключения, а `SourceCodePanel` теперь рендерится только при `showSource === true`.
- Изменён набор пропсов и местами обновлён JSX в `src/features/ui-components/NewUIComponentViewer.tsx` для поддержания условного рендера панели кода.

### Testing
- Запущен `npx eslint src/features/ui-components/NewUIComponentViewer.tsx`, проверка прошла успешно.
- Запущен репозиторный линт `npm run lint`, который падает на существующих, не связанных с этим изменением проблемах кода (предыдущие ошибки в проекте), то есть изменения в файле не вызвали новых глобальных ошибок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0abcead824832c9e303e0f8be51f15)