### PR TITLE
Add source viewer toggle, include .ts files in loader and polish settings/preview UI

### DIFF
--- a/src/features/ui-components/NewUIComponentViewer.tsx
+++ b/src/features/ui-components/NewUIComponentViewer.tsx
@@ -5,7 +5,7 @@ import { createPortal } from 'react-dom';
 import { useTheme } from '@/shared/contexts/ThemeContext';
 import {
   X, Minimize2, Play, RefreshCcw,
-  Settings, PanelRight, PanelRightClose, ChevronDown, MonitorSmartphone,
+  Settings, PanelRight, PanelRightClose, ChevronDown,
 } from 'lucide-react';
 import { loadComponent, getDefaultProps } from './loader';
 import { ComponentWrapper } from './ComponentWrapper';
@@ -17,6 +17,7 @@ type PropValue = string | number | boolean | string[] | undefined;
 type ComponentPropsMap = Record<string, PropValue>;
 type AnyComponent = React.ComponentType<Record<string, PropValue>>;
 type TabType = 'universal' | 'specific' | 'source';
+type SettingsAction = 'run' | 'reset' | 'source' | 'hide' | 'collapse';
 
 interface LoadedComponentData {
   config: ComponentConfig;
@@ -93,10 +94,6 @@ function Pill({ onClick, title, label, icon, t, active, danger, compact }: Reado
       {label && <span style={{ fontSize: compact ? 9 : 10, fontWeight: active ? 600 : 400, whiteSpace: 'nowrap', lineHeight: 1 }}>{label}</span>}
     </button>
   );
-}
-
-function Divider({ t }: Readonly<{ t: T }>) {
-  return <div style={{ width: 1, height: 22, background: t.barBorder, margin: '0 2px', flexShrink: 0 }} />;
 }
 
 const DEFAULT_UNIVERSAL_PROPS: UniversalProps = {
@@ -612,9 +609,10 @@ const MobileBottomSheet: React.FC<{ config: ComponentConfig; componentProps: Com
   );
 };
 
-const FullscreenModal: React.FC<ComponentRenderProps & { config: ComponentConfig; onClose: () => void; onRefresh: () => void; onPropChange: (name: string, v: PropValue) => void; onUniversalPropChange: (key: keyof UniversalProps, v: PropValue) => void; onReset: () => void; t: T }> = ({ Component, componentProps, universalProps, refreshKey, isDark, componentCategory, config, onClose, onRefresh, onPropChange, onUniversalPropChange, onReset, t }) => {
+const FullscreenModal: React.FC<ComponentRenderProps & { config: ComponentConfig; fileContents: Record<string, string>; onClose: () => void; onRefresh: () => void; onPropChange: (name: string, v: PropValue) => void; onUniversalPropChange: (key: keyof UniversalProps, v: PropValue) => void; onReset: () => void; t: T }> = ({ Component, componentProps, universalProps, refreshKey, isDark, componentCategory, config, fileContents, onClose, onRefresh, onPropChange, onUniversalPropChange, onReset, t }) => {
   const [activeTab, setActiveTab] = useState<TabType>('universal');
   const [panelOpen, setPanelOpen] = useState(true);
+  const [sourceVisible, setSourceVisible] = useState(false);
   const isMobile = useIsMobile();
   useEffect(() => {
     document.body.style.overflow = 'hidden';
@@ -624,13 +622,12 @@ const FullscreenModal: React.FC<ComponentRenderProps & { config: ComponentConfig
   }, [onClose]);
   return createPortal(
     <div style={{ position: 'fixed', inset: 0, zIndex: 9999, background: t.outerBg, display: 'flex', flexDirection: 'column' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '8px 10px', flexShrink: 0, borderBottom: `1px solid ${t.barBorder}`, background: t.barBg }}>
-        <div style={{ fontSize: 13, fontWeight: 600, color: t.fgMuted, padding: '3px 9px', borderRadius: 7, background: t.btnBg, border: `1px solid ${t.barBorder}`, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 160, flexShrink: 1 }}>{config.name}</div>
-        <div style={{ flex: 1 }} />
-        <Pill onClick={onRefresh} title="Перезапустить" label=""   icon={<Play       size={14} />} t={t} />
-        <Pill onClick={onReset}   title="Сбросить"      label="Сбросить" icon={<RefreshCcw size={14} />} t={t} />
-        {!isMobile && (<><Divider t={t} /><Pill onClick={() => setPanelOpen(v => !v)} title={panelOpen ? 'Скрыть панель' : 'Показать панель'} label={panelOpen ? 'Скрыть' : 'Панель'} icon={panelOpen ? <PanelRightClose size={14} /> : <PanelRight size={14} />} t={t} active={panelOpen} /></>)}
-        <Pill onClick={onClose} title="Свернуть (Esc)" label="Свернуть" icon={<Minimize2 size={14} />} t={t} />
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', flexShrink: 0, borderBottom: `1px solid ${t.barBorder}`, background: t.barBg, overflowX: 'auto' }}>
+        <button onClick={onRefresh} style={{ display: 'flex', alignItems: 'center', gap: 6, borderRadius: 999, border: `1px solid ${t.btnBdr}`, background: t.btnBg, color: t.btnClr, padding: '8px 12px', fontSize: 12, whiteSpace: 'nowrap', cursor: 'pointer' }}><Play size={14} />Запуск анимации</button>
+        <button onClick={onReset} style={{ display: 'flex', alignItems: 'center', gap: 6, borderRadius: 999, border: `1px solid ${t.btnBdr}`, background: t.btnBg, color: t.btnClr, padding: '8px 12px', fontSize: 12, whiteSpace: 'nowrap', cursor: 'pointer' }}><RefreshCcw size={14} />Сбросить настройки</button>
+        <button onClick={() => setSourceVisible(v => !v)} style={{ display: 'flex', alignItems: 'center', gap: 6, borderRadius: 999, border: `1px solid ${t.btnBdr}`, background: sourceVisible ? t.tabActBg : t.btnBg, color: sourceVisible ? t.tabActClr : t.btnClr, padding: '8px 12px', fontSize: 12, whiteSpace: 'nowrap', cursor: 'pointer' }}><PanelRight size={14} />{sourceVisible ? 'Скрыть код' : 'Посмотреть код'}</button>
+        {!isMobile && <button onClick={() => setPanelOpen(v => !v)} style={{ display: 'flex', alignItems: 'center', gap: 6, borderRadius: 999, border: `1px solid ${t.btnBdr}`, background: t.btnBg, color: t.btnClr, padding: '8px 12px', fontSize: 12, whiteSpace: 'nowrap', cursor: 'pointer' }}>{panelOpen ? <PanelRightClose size={14} /> : <PanelRight size={14} />}{panelOpen ? 'Скрыть меню настроек' : 'Показать меню настроек'}</button>}
+        <button onClick={onClose} style={{ display: 'flex', alignItems: 'center', gap: 6, borderRadius: 999, border: `1px solid ${t.btnBdr}`, background: t.btnBg, color: t.btnClr, padding: '8px 12px', fontSize: 12, whiteSpace: 'nowrap', cursor: 'pointer', marginLeft: 'auto' }}><Minimize2 size={14} />Свернуть меню</button>
       </div>
       <div style={{ flex: 1, display: 'flex', overflow: 'hidden', position: 'relative' }}>
         <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: isMobile ? '24px 16px' : 48, overflow: 'hidden', paddingBottom: isMobile ? 68 : undefined, color: t.fg, minWidth: 0, minHeight: 0 }}>
@@ -643,19 +640,17 @@ const FullscreenModal: React.FC<ComponentRenderProps & { config: ComponentConfig
         )}
         {isMobile && <MobileBottomSheet config={config} componentProps={componentProps} universalProps={universalProps} onPropChange={onPropChange} onUniversalPropChange={onUniversalPropChange} t={t} />}
       </div>
+      {sourceVisible && <SourceCodePanel fileContents={fileContents} t={t} />}
     </div>,
     document.body,
   );
 };
 
-const PreviewPanel: React.FC<ComponentRenderProps & { config: ComponentConfig; onRefresh: () => void; onFullscreen: () => void; onOpenSettings: () => void; t: T; loading: boolean; isMobile: boolean }> = ({ config, Component, componentProps, universalProps, refreshKey, isDark, componentCategory, onRefresh, onFullscreen, onOpenSettings, t, loading, isMobile }) => (
+const PreviewPanel: React.FC<ComponentRenderProps & { onOpenSettings: () => void; t: T; loading: boolean; isMobile: boolean }> = ({ Component, componentProps, universalProps, refreshKey, isDark, componentCategory, onOpenSettings, t, loading, isMobile }) => (
   <div style={{ borderRadius: 12, border: `1px solid ${t.outerBorder}`, background: t.outerBg, boxShadow: t.outerShadow, display: 'flex', flexDirection: 'column', width: '100%', minWidth: 0, overflow: 'hidden' }}>
     <div style={{ display: 'flex', alignItems: 'center', gap: isMobile ? 4 : 6, padding: isMobile ? '8px' : '8px 10px', borderBottom: `1px solid ${t.barBorder}`, background: t.barBg, flexWrap: 'nowrap', minWidth: 0 }}>
-      {!isMobile && <div style={{ fontSize: 13, fontWeight: 600, color: t.fgMuted, padding: '3px 9px', borderRadius: 7, background: t.btnBg, border: `1px solid ${t.barBorder}`, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 200, flexShrink: 1 }}>{config.name}</div>}
       <div style={{ flex: 1 }} />
-      <Pill onClick={onRefresh}      title="Перезапустить" label=""     icon={<Play      size={14} />} t={t} compact={isMobile} />
-      <Pill onClick={onFullscreen}   title="Развернуть"    label=""      icon={<MonitorSmartphone size={14} />} t={t} compact={isMobile} />
-      <Pill onClick={onOpenSettings} title="Настройки"     label=""   icon={<Settings  size={14} />} t={t} compact={isMobile} />
+      <Pill onClick={onOpenSettings} title="Открыть меню настроек" label="" icon={<Settings size={14} />} t={t} compact={isMobile} />
     </div>
 
     {/* Область предпросмотра фиксированной высоты без прыжков */}
@@ -687,30 +682,46 @@ const PreviewPanel: React.FC<ComponentRenderProps & { config: ComponentConfig; o
 
     <div style={{ padding: '6px 12px', borderTop: `1px solid ${t.barBorder}`, fontSize: 11, color: t.footerClr, display: 'flex', alignItems: 'center', justifyContent: 'space-between', userSelect: 'none', background: t.outerBg, flexShrink: 0 }}>
       <span>Компонент</span>
-      <span style={{ fontFamily: 'ui-monospace, monospace', fontSize: 10, opacity: 0.7 }}>{config.id}</span>
     </div>
   </div>
 );
 
-const SettingsPanel: React.FC<ComponentRenderProps & { config: ComponentConfig; onClose: () => void; onPropChange: (name: string, v: PropValue) => void; onUniversalPropChange: (key: keyof UniversalProps, v: PropValue) => void; onRefresh: () => void; onReset: () => void; t: T }> = (props) => {
+const SettingsPanel: React.FC<ComponentRenderProps & { config: ComponentConfig; onClose: () => void; onPropChange: (name: string, v: PropValue) => void; onUniversalPropChange: (key: keyof UniversalProps, v: PropValue) => void; onRefresh: () => void; onReset: () => void; onToggleSource: () => void; sourceVisible: boolean; t: T }> = (props) => {
   const { isDark, config, onClose, onRefresh, onReset, t } = props;
   const [activeTab, setActiveTab] = useState<TabType>('universal');
+
+  const menuItems: Array<{ id: SettingsAction; label: string; icon: React.ReactNode }> = [
+    { id: 'run', label: 'Запуск анимации', icon: <Play size={14} /> },
+    { id: 'reset', label: 'Сбросить настройки', icon: <RefreshCcw size={14} /> },
+    { id: 'source', label: props.sourceVisible ? 'Скрыть код' : 'Посмотреть код', icon: <PanelRight size={14} /> },
+    { id: 'hide', label: 'Скрыть меню настроек', icon: <PanelRightClose size={14} /> },
+    { id: 'collapse', label: 'Свернуть меню', icon: <X size={14} /> },
+  ];
+
+  const handleMenuAction = (action: SettingsAction) => {
+    if (action === 'run') onRefresh();
+    if (action === 'reset') onReset();
+    if (action === 'source') props.onToggleSource();
+    if (action === 'hide' || action === 'collapse') onClose();
+  };
+
   return (
     <div style={{ borderRadius: 12, border: `1px solid ${t.outerBorder}`, background: t.outerBg, boxShadow: t.outerShadow, display: 'flex', flexDirection: 'column', maxHeight: 'calc(100dvh - 3rem)', overflow: 'hidden' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', borderBottom: `1px solid ${t.barBorder}`, background: t.barBg, overflowX: 'auto' }}>
+        {menuItems.map((item) => (
+          <button key={item.id} onClick={() => handleMenuAction(item.id)} style={{ display: 'flex', alignItems: 'center', gap: 6, borderRadius: 999, border: `1px solid ${t.btnBdr}`, background: t.btnBg, color: t.btnClr, padding: '7px 11px', fontSize: 11, whiteSpace: 'nowrap', cursor: 'pointer' }}>
+            {item.icon}
+            {item.label}
+          </button>
+        ))}
+      </div>
       <div style={{ height: 220, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20, borderBottom: `1px solid ${t.barBorder}`, color: t.fg, overflow: 'hidden', boxSizing: 'border-box' }}>
         <ComponentRender Component={props.Component} componentProps={props.componentProps} universalProps={props.universalProps} refreshKey={props.refreshKey} isDark={isDark} componentCategory={props.componentCategory} />
       </div>
       <SettingsContent activeTab={activeTab} onTabSelect={setActiveTab} config={config} componentProps={props.componentProps} universalProps={props.universalProps} onPropChange={props.onPropChange} onUniversalChange={props.onUniversalPropChange} t={t} />
-      <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: 6, padding: '8px 10px', borderTop: `1px solid ${t.barBorder}`, background: t.barBg, flexWrap: 'wrap', rowGap: 6 }}>
-        <Pill onClick={onRefresh} title="Перезапустить" label=""   icon={<Play       size={14} />} t={t} />
-        <Pill onClick={onReset}   title="Сбросить всё"  label="Сбросить" icon={<RefreshCcw size={14} />} t={t} />
-        <div style={{ flex: 1 }} />
-        <Pill onClick={onClose}   title="Закрыть"       label="Закрыть"  icon={<X          size={14} />} t={t} />
-      </div>
     </div>
   );
 };
-
 
 
 const SourceCodePanel: React.FC<{ fileContents: Record<string, string>; t: T }> = ({ fileContents, t }) => {
@@ -718,7 +729,13 @@ const SourceCodePanel: React.FC<{ fileContents: Record<string, string>; t: T }> 
   const [activeFile, setActiveFile] = useState(files[0]?.[0] ?? '');
 
   useEffect(() => {
-    if (!activeFile && files[0]?.[0]) setActiveFile(files[0][0]);
+    if (!files.length) {
+      setActiveFile('');
+      return;
+    }
+    if (!activeFile || !files.some(([name]) => name === activeFile)) {
+      setActiveFile(files[0][0]);
+    }
   }, [activeFile, files]);
 
   const activeCode = files.find(([name]) => name === activeFile)?.[1] ?? '';
@@ -739,7 +756,7 @@ const SourceCodePanel: React.FC<{ fileContents: Record<string, string>; t: T }> 
           );
         })}
       </div>
-      <pre style={{ margin: 0, padding: 12, maxHeight: 320, overflow: 'auto', fontSize: 12, lineHeight: 1.45, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace', color: t.fg, background: t.panelBg }}>
+      <pre style={{ margin: 0, padding: 12, maxHeight: 320, overflow: 'auto', fontSize: 12, lineHeight: 1.45, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace', color: t.fg, background: t.panelBg, whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', tabSize: 2 }}>
         <code>{activeCode}</code>
       </pre>
     </div>
@@ -760,6 +777,7 @@ const UIComponentViewer: React.FC<{ componentId: string }> = ({ componentId }) =
   const t = tk(isDark);
 
   const [settingsOpen,   setSettingsOpen]   = useState(false);
+  const [sourceVisible,  setSourceVisible]  = useState(true);
   const [isFullscreen,   setIsFullscreen]   = useState(false);
   const [refreshKey,     setRefreshKey]     = useState(0);
   const [componentProps, setComponentProps] = useState<ComponentPropsMap>({});
@@ -828,21 +846,20 @@ const UIComponentViewer: React.FC<{ componentId: string }> = ({ componentId }) =
           onUniversalPropChange={handleUniversalChange}
           onRefresh={handleRefresh}
           onReset={handleReset}
+          onToggleSource={() => setSourceVisible(v => !v)}
+          sourceVisible={sourceVisible}
           t={t}
         />
       ) : (
         <PreviewPanel
           {...shared}
-          config={effectiveData.config}
-          onRefresh={handleRefresh}
-          onFullscreen={() => setIsFullscreen(true)}
-          onOpenSettings={() => setSettingsOpen(true)}
+          onOpenSettings={() => setIsFullscreen(true)}
           t={t}
           loading={loading}
           isMobile={isMobile}
         />
       )}
-      <SourceCodePanel fileContents={effectiveData.fileContents} t={t} />
+      {sourceVisible && <SourceCodePanel fileContents={effectiveData.fileContents} t={t} />}
       {isFullscreen && componentData && (
         <FullscreenModal
           {...shared}

--- a/src/features/ui-components/loader.ts
+++ b/src/features/ui-components/loader.ts
@@ -1,7 +1,7 @@
 import { registry } from './registry';
 import type { ComponentConfig, LoadedComponent } from '../types';
 
-const sourceModules = import.meta.glob('../*/*.tsx', { query: '?raw', import: 'default' });
+const sourceModules = import.meta.glob('../*/*.{ts,tsx}', { query: '?raw', import: 'default' });
 
 type PropValue = string | number | boolean | string[] | undefined;
 
@@ -21,8 +21,8 @@ function pickMainSourcePath(componentId: string, config: ComponentConfig): strin
     `../${componentId}/index.ts`,
   ].filter((p): p is string => !!p && !p.endsWith('undefined'));
 
-  const allTsx = Object.keys(sourceModules).filter(k => k.startsWith(`../${componentId}/`));
-  const candidates = [...new Set([...preferred, ...allTsx])];
+  const allSourceFiles = Object.keys(sourceModules).filter(k => k.startsWith(`../${componentId}/`));
+  const candidates = [...new Set([...preferred, ...allSourceFiles])];
 
   for (const candidate of candidates) {
     if (sourceModules[candidate]) return candidate;
@@ -33,14 +33,22 @@ function pickMainSourcePath(componentId: string, config: ComponentConfig): strin
 
 async function loadFileContents(componentId: string, config: ComponentConfig): Promise<Record<string, string>> {
   const sourcePath = pickMainSourcePath(componentId, config);
-  if (!sourcePath) return {};
+  const allSourcePaths = Object.keys(sourceModules).filter(k => k.startsWith(`../${componentId}/`));
+  if (!sourcePath && allSourcePaths.length === 0) return {};
+
+  const orderedPaths = sourcePath
+    ? [sourcePath, ...allSourcePaths.filter(path => path !== sourcePath)]
+    : allSourcePaths;
 
   try {
-    const source = await sourceModules[sourcePath]() as string;
-    const fileName = sourcePath.split('/').at(-1) ?? `${componentId}.tsx`;
-    return { [fileName]: source };
+    const entries = await Promise.all(orderedPaths.map(async (path) => {
+      const source = await sourceModules[path]() as string;
+      const relativeName = path.replace(`../${componentId}/`, '');
+      return [relativeName, source] as const;
+    }));
+    return Object.fromEntries(entries);
   } catch (error) {
-    console.warn('[loader] Не удалось загрузить исходник компонента:', sourcePath, error);
+    console.warn('[loader] Не удалось загрузить исходник компонента:', componentId, error);
     return {};
   }
 }


### PR DESCRIPTION
### Motivation
- Provide an on-demand source code viewer for components and make the loader pick up both `.ts` and `.tsx` sources. 
- Improve settings/fullscreen UX by consolidating actions into a menu and adding clearer controls for running/resetting and toggling the source panel. 
- Make source panel rendering more robust when files are missing and improve code formatting in the viewer.

### Description
- UI: introduce `sourceVisible` state and wire it through `UIComponentViewer`, `FullscreenModal`, and `SettingsPanel` to show/hide the `SourceCodePanel` conditionally, and move the source viewer into fullscreen; replace several small `Pill` controls with larger action buttons in top bars. 
- Settings: add a `SettingsAction` enum and a compact action menu in `SettingsPanel` which triggers `run`, `reset`, `source`, `hide`, and `collapse` behaviors and forwards `onToggleSource`. 
- Source viewer: make `SourceCodePanel` resilient to no-files, pick the active file reliably, present files in an order with the main source first, and improve `<pre>` styling with `white-space: pre-wrap`, `overflow-wrap: anywhere` and `tab-size: 2`. 
- Loader: expand glob to `../*/*.{ts,tsx}` so `.ts` files are found, gather all source files for a component, choose a preferred main file when available, and return an ordered map of file contents (main first). Improve error logging when loading sources. 
- Misc: update component/prop types to accommodate `fileContents`, remove unused imports/`Divider` and tidy a few layout texts and labels.

### Testing
- Ran TypeScript type-check (`tsc`) and a local dev build; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ac46ebe34832ca1c9df9fc2d3b960)