### PR TITLE
Refactor landing visuals, remove EcoCard and use FeatureCard for ecosystem

### DIFF
--- a/src/features/general/components/GeneralPage.tsx
+++ b/src/features/general/components/GeneralPage.tsx
@@ -388,7 +388,6 @@ const SecurityCheckVisual: React.FC = () => (
         <strong>XSS и RCE</strong>
       </div>
     </div>
-    <div className="security-check-vignette" />
   </div>
 );
 
@@ -399,8 +398,9 @@ const SecureAccessVisual: React.FC = () => (
       <path className="access-line access-line-laptop" d="M310 118 C382 76 430 68 510 68" />
       <path className="access-line access-line-phone" d="M310 118 C382 162 430 172 510 172" />
       <path className="access-pulse access-pulse-1" d="M120 118 C210 118 258 118 310 118 C382 76 430 68 510 68" />
-      <path className="access-pulse access-pulse-2" d="M510 172 C430 172 382 162 310 118 C258 118 210 118 120 118" />
+      <path className="access-pulse access-pulse-2" d="M120 118 C210 118 258 118 310 118 C382 162 430 172 510 172" />
       <path className="access-pulse access-pulse-3" d="M510 68 C430 68 382 76 310 118 C258 118 210 118 120 118" />
+      <path className="access-pulse access-pulse-4" d="M510 172 C430 172 382 162 310 118 C258 118 210 118 120 118" />
     </svg>
     <div className="access-device access-device-desktop access-device-left"><span /></div>
     <div className="access-device access-device-laptop"><span /></div>
@@ -409,7 +409,6 @@ const SecureAccessVisual: React.FC = () => (
       <span className="secure-access-tooltip-dot" />
       подключено через <strong>mTLS</strong>
     </div>
-    <div className="secure-access-vignette" />
   </div>
 );
 
@@ -459,7 +458,6 @@ const FeatureCard: React.FC<FeatureCardProps> = ({ title, text, isNegative, full
   const titleC = isNegative ? 'rgba(255,255,255,0.9)' : 'rgba(0,0,0,0.88)';
   const textC  = isNegative ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.65)';
   const badgeC = isNegative ? 'rgba(255,255,255,0.42)' : 'rgba(0,0,0,0.42)';
-  const badgeBg = isNegative ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.05)';
   const hasVisual = Boolean(visual);
   const visualClass = visual ? `feature-card--${visual}` : '';
 
@@ -509,9 +507,6 @@ const FeatureCard: React.FC<FeatureCardProps> = ({ title, text, isNegative, full
             letterSpacing: '0.12em',
             textTransform: 'uppercase',
             color:         badgeC,
-            background:    badgeBg,
-            borderRadius:  999,
-            padding:       '0.18rem 0.55rem',
             marginBottom:  '0.75rem',
             fontFamily:    'ui-monospace, monospace',
           }}>
@@ -571,14 +566,7 @@ const SecuritySection: React.FC<SecuritySectionProps> = ({ isNegative, navOffset
           isolation: isolate;
           background: var(--visual-card-surface, rgba(255,255,255,0.02)) !important;
         }
-        .feature-card--visual::before {
-          content: '';
-          position: absolute;
-          inset: 0;
-          background: radial-gradient(circle at 52% 22%, var(--visual-fill-top), transparent 28%);
-          pointer-events: none;
-          z-index: 0;
-        }
+        .feature-card--visual::before { display: none; }
         .feature-card-copy--visual {
           padding-top: clamp(11.8rem, 18vw, 13.25rem) !important;
         }
@@ -595,7 +583,6 @@ const SecuritySection: React.FC<SecuritySectionProps> = ({ isNegative, navOffset
           pointer-events: none;
           z-index: 0;
           background:
-            radial-gradient(circle at 51% 39%, var(--visual-fill-top), transparent 20%),
             linear-gradient(180deg, color-mix(in srgb, var(--visual-card-surface, #0f0f0f) 4%, transparent), transparent 58%, var(--visual-card-surface, #0f0f0f) 100%);
         }
         .security-analysis-visual::before,
@@ -844,6 +831,7 @@ const SecuritySection: React.FC<SecuritySectionProps> = ({ isNegative, navOffset
         }
         .access-pulse-2 { animation-delay: 1.8s; }
         .access-pulse-3 { animation-delay: 3.6s; }
+        .access-pulse-4 { animation-delay: 5.4s; }
         .access-device {
           position: absolute;
           display: grid;
@@ -1173,127 +1161,6 @@ const SecuritySection: React.FC<SecuritySectionProps> = ({ isNegative, navOffset
 };
 
 
-// ─── EcoCard ──────────────────────────────────────────────────────────────────
-
-interface EcoCardProps {
-  title:       string;
-  description: string;
-  link?:       string;
-  linkLabel?:  string;
-  isNegative:  boolean;
-  extraLinks?: Array<{ href: string; label: string }>;
-}
-
-const EcoCard: React.FC<EcoCardProps> = ({
-  title, description, link, linkLabel, isNegative, extraLinks,
-}) => {
-  const outerBorder  = isNegative ? 'rgba(255,255,255,0.1)'  : 'rgba(0,0,0,0.1)';
-  const innerBorder  = isNegative ? 'rgba(255,255,255,0.1)'  : 'rgba(0,0,0,0.1)';
-  const innerBg      = isNegative ? '#0a0a0a'                : '#E8E7E3';
-  const innerShadow  = isNegative ? '0px 0px 27px 0px rgba(45,45,45,0.3)' : 'none';
-  const titleC       = isNegative ? 'rgba(255,255,255,0.9)'  : 'rgba(0,0,0,0.88)';
-  const textC        = isNegative ? 'rgba(255,255,255,0.65)' : 'rgba(0,0,0,0.6)';
-  const linkClr      = isNegative ? 'rgba(255,255,255,0.35)' : 'rgba(0,0,0,0.38)';
-  const linkHov      = isNegative ? 'rgba(255,255,255,0.75)' : 'rgba(0,0,0,0.75)';
-
-  return (
-    <div style={{
-      position:     'relative',
-      borderRadius: '1.25rem',
-      border:       `0.75px solid ${outerBorder}`,
-      padding:      '0.5rem',
-    }}>
-      <GlowingEffectInline
-        spread={40} glow disabled={false}
-        proximity={64} inactiveZone={0.01}
-        borderWidth={3} isNegative={isNegative}
-      />
-
-      <div style={{
-        position:      'relative',
-        borderRadius:  '0.9rem',
-        border:        `0.75px solid ${innerBorder}`,
-        background:    innerBg,
-        boxShadow:     innerShadow,
-        overflow:      'hidden',
-        padding:       '1.5rem',
-        display:       'flex',
-        flexDirection: 'column',
-        gap:           '0.6rem',
-        minHeight:     '180px',
-      }}>
-        <div style={{
-          fontSize:   'clamp(1rem, 1.5vw, 1.15rem)',
-          fontWeight: 700,
-          color:      titleC,
-          lineHeight: 1.25,
-          fontFamily: 'Inter, system-ui, sans-serif',
-        }}>
-          {title}
-        </div>
-
-        <div style={{
-          fontSize:   'clamp(0.9rem, 1.3vw, 1rem)',
-          color:      textC,
-          lineHeight: 1.65,
-          fontFamily: 'Inter, system-ui, sans-serif',
-          flex:       1,
-        }}>
-          {description}
-        </div>
-
-        {link && (
-          <a
-            href={link}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{
-              display:        'inline-flex',
-              alignItems:     'center',
-              gap:            4,
-              fontSize:       '0.75rem',
-              color:          linkClr,
-              textDecoration: 'none',
-              marginTop:      '0.25rem',
-              fontFamily:     'ui-monospace, monospace',
-            }}
-            onMouseEnter={e => { (e.currentTarget as HTMLAnchorElement).style.color = linkHov; }}
-            onMouseLeave={e => { (e.currentTarget as HTMLAnchorElement).style.color = linkClr; }}
-          >
-            {linkLabel} ↗
-          </a>
-        )}
-
-        {extraLinks && extraLinks.length > 0 && (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.3rem', marginTop: '0.25rem' }}>
-            {extraLinks.map(el => (
-              <a
-                key={el.href}
-                href={el.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{
-                  display:        'inline-flex',
-                  alignItems:     'center',
-                  gap:            4,
-                  fontSize:       '0.75rem',
-                  color:          linkClr,
-                  textDecoration: 'none',
-                  fontFamily:     'ui-monospace, monospace',
-                }}
-                onMouseEnter={e => { (e.currentTarget as HTMLAnchorElement).style.color = linkHov; }}
-                onMouseLeave={e => { (e.currentTarget as HTMLAnchorElement).style.color = linkClr; }}
-              >
-                {el.label} ↗
-              </a>
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
-  );
-};
-
 // ─── EcosystemSection ─────────────────────────────────────────────────────────
 
 interface EcosystemSectionProps {
@@ -1323,17 +1190,10 @@ const EcosystemSection: React.FC<EcosystemSectionProps> = ({ isNegative, navOffs
         .eco-header {
           margin-bottom: clamp(3rem, 5vw, 4.5rem);
         }
-        .eco-content {
-          display: block;
-        }
         .eco-cards {
           display: grid;
           grid-template-columns: repeat(3, minmax(0, 1fr));
           gap: 1rem;
-        }
-        @media (max-width: 900px) {
-          .eco-content { display: block; }
-          .eco-cards { grid-template-columns: 1fr; }
         }
         .eco-rotating-text {
           overflow: visible !important;
@@ -1349,6 +1209,7 @@ const EcosystemSection: React.FC<EcosystemSectionProps> = ({ isNegative, navOffs
           flex-wrap: nowrap;
           white-space: nowrap;
         }
+        @media (max-width: 1200px) { .eco-cards { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
         @media (max-width: 640px) {
           .eco-heading-inline {
             flex-direction: column;
@@ -1356,6 +1217,7 @@ const EcosystemSection: React.FC<EcosystemSectionProps> = ({ isNegative, navOffs
             white-space: normal;
             gap: 0.1em;
           }
+          .eco-cards { grid-template-columns: 1fr; }
         }
       `}</style>
 
@@ -1391,28 +1253,27 @@ const EcosystemSection: React.FC<EcosystemSectionProps> = ({ isNegative, navOffs
           </p>
         </div>
 
-        <div className="eco-content">
-          {/* Карточки экосистемы */}
-          <div className="eco-cards">
-            <EcoCard
-              isNegative={isNegative}
-              title="Opensophy Hub (O.Hub)"
-              description="Гибридная open-source платформа для документации и публикации контента. Подходит для технических команд, авторов и всех, кто хочет красиво и структурировано делиться знаниями."
-              link="https://github.com/opensophy-projects/hub"
-              linkLabel="opensophy-projects/hub"
-            />
-            <EcoCard
-              isNegative={isNegative}
-              title="Opensophy mTLS (O.mTLS)"
-              description="Инструмент для быстрого создания и управления mTLS-сертификатами. Для тех, кто хочет надёжно закрыть доступ к своим сервисам и серверам без лишней головной боли."
-            />
-            <EcoCard
-              isNegative={isNegative}
-              title="Opensophy UI (O.UI)"
-              description="Библиотека готовых React-компонентов с живым превью и настройками. Анимации, интерактивные блоки, кастомные элементы и фирменные компоненты Opensophy — для разработчиков и дизайнеров, которые ценят время."
-            />
-          </div>
+        <div className="eco-cards">
+          <FeatureCard
+            isNegative={isNegative}
+            title="Opensophy Hub (O.Hub)"
+            badge="веб-проект"
+            text="Гибридная open-source платформа для документации и публикации контента. Подходит для технических команд, авторов и всех, кто хочет красиво и структурировано делиться знаниями."
+          />
+          <FeatureCard
+            isNegative={isNegative}
+            title="Opensophy mTLS (O.mTLS)"
+            badge="скрипт"
+            text="Инструмент для быстрого создания и управления mTLS-сертификатами. Для тех, кто хочет надёжно закрыть доступ к своим сервисам и серверам без лишней головной боли."
+          />
+          <FeatureCard
+            isNegative={isNegative}
+            title="Opensophy UI (O.UI)"
+            badge="веб-проект"
+            text="Библиотека готовых React-компонентов с живым превью и настройками. Анимации, интерактивные блоки, кастомные элементы и фирменные компоненты Opensophy — для разработчиков и дизайнеров."
+          />
         </div>
+
       </div>
     </section>
   );


### PR DESCRIPTION
### Motivation
- Simplify and standardize visual elements and responsive layout for the landing page visuals and ecosystem cards. 
- Remove a specialized `EcoCard` component in favor of reusing the existing `FeatureCard` to reduce duplication and maintenance.

### Description
- Removed the `EcoCard` component and replaced the ecosystem cards markup to render three `FeatureCard` instances in `EcosystemSection` with appropriate `title`, `badge`, and `text` props. 
- Adjusted SVG animation paths in `SecureAccessVisual` by swapping the `d` for `access-pulse-2` and adding a new `access-pulse-4` path and animation delay to extend pulse sequencing. 
- Simplified `FeatureCard` badge styling by removing `badgeBg` and eliminating the badge `background`, `borderRadius`, and `padding` inline styles so badges render as inline text only. 
- Disabled the visual radial overlay on `.feature-card--visual::before` by replacing the gradient block with `.feature-card--visual::before { display: none; }` and removed an earlier radial gradient from visual backgrounds. 
- Removed a few vignette elements (`security-check-vignette`, `secure-access-vignette`) and cleaned up related CSS positions and responsive rules for `.eco-cards` to provide improved breakpoints (`repeat(2, ...)` at 1200px and single column under 640px).

### Testing
- Ran TypeScript type check via `tsc` which completed successfully. 
- Ran unit tests via `yarn test` and they all passed. 
- Ran linter via `yarn lint` with no new issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a104d3d5bcc832fab79a47b85ec6a92)