### PR TITLE
Dev panel: UI polish, docs search, parse/slug improvements and robust WebSocket URL

### DIFF
--- a/public/data/site-config.json
+++ b/public/data/site-config.json
@@ -2,6 +2,6 @@
   "useLanding": true,
   "showDotWaveBackground": true,
   "favicon": "/favicon.png",
-  "lightLogo": "",
+  "lightLogo": "/light_logo.png",
   "darkLogo": "/dark_logo.png"
 }

--- a/public/data/site-config.json
+++ b/public/data/site-config.json
@@ -3,5 +3,5 @@
   "showDotWaveBackground": true,
   "favicon": "/favicon.png",
   "lightLogo": "",
-  "darkLogo": ""
+  "darkLogo": "/dark_logo.png"
 }

--- a/public/data/site-config.json
+++ b/public/data/site-config.json
@@ -2,6 +2,6 @@
   "useLanding": true,
   "showDotWaveBackground": true,
   "favicon": "/favicon.png",
-  "lightLogo": "/light_logo.png",
-  "darkLogo": "/dark_logo.png"
+  "lightLogo": "",
+  "darkLogo": ""
 }

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -7,7 +7,7 @@
   <!-- Главная страница -->
   <url>
     <loc>https://opensophy.com/</loc>
-    <lastmod>2026-05-22</lastmod>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/src/features/dev-panel/DevPanel.tsx
+++ b/src/features/dev-panel/DevPanel.tsx
@@ -352,7 +352,7 @@ export default function DevPanel() {
           <div style={{
             display: 'flex', background: t.surface,
             borderBottom: `1px solid ${t.border}`,
-            flexShrink: 0, padding: '0 4px',
+            flexShrink: 0, padding: '4px',
             overflowX: 'auto',
           }}>
             {TABS.map(tb => {
@@ -363,11 +363,11 @@ export default function DevPanel() {
                   onMouseDown={e => { e.preventDefault(); setTab(tb.id); }}
                   style={{
                     display: 'flex', alignItems: 'center', gap: 5,
-                    padding: '9px 12px', border: 'none',
-                    borderBottom: `2px solid ${active ? t.fg : 'transparent'}`,
-                    background: 'transparent',
+                    padding: '8px 10px', border: `1px solid ${active ? t.borderStrong : 'transparent'}`,
+                    borderRadius: 8,
+                    background: active ? t.surfaceHov : 'transparent',
                     color: active ? t.fg : t.fgMuted,
-                    fontSize: 11, fontWeight: active ? 600 : 400,
+                    fontSize: 11, fontWeight: active ? 600 : 500,
                     cursor: 'pointer', fontFamily: t.mono,
                     flexShrink: 0, outline: 'none',
                   }}

--- a/src/features/dev-panel/panels/AssetsPanel.tsx
+++ b/src/features/dev-panel/panels/AssetsPanel.tsx
@@ -88,15 +88,15 @@ function DropZone({ label, accept, onFiles, loading, hint, t }: Readonly<{
           ? <Loader2 size={22} style={{ color: t.fgMuted, animation: 'devSpin 1s linear infinite', margin: '0 auto 10px' }}/>
           : <Upload size={22} style={{ color: dragOver ? t.fg : t.fgMuted, margin: '0 auto 10px' }}/>
         }
-        <div style={{ fontSize: 13, color: dragOver ? t.fg : t.fgMuted, fontWeight: 500, fontFamily: t.mono }}>
+        <div style={{ fontSize: 16, color: dragOver ? t.fg : t.fgMuted, fontWeight: 500, fontFamily: t.mono }}>
           {loading ? 'Загружаем...' : label}
         </div>
-        <div style={{ fontSize: 11, color: t.fgSub, marginTop: 4 }}>
-          {loading ? '' : 'Перетащи или кликни'}
+        <div style={{ fontSize: 13, color: t.fgSub, marginTop: 4 }}>
+          {loading ? '' : 'Перетащите файл сюда или нажмите для выбора'}
         </div>
       </button>
       {hint && (
-        <div style={{ fontSize: 10, color: t.fgSub, marginTop: 6, paddingLeft: 2 }}>{hint}</div>
+        <div style={{ fontSize: 12, color: t.fgSub, marginTop: 6, paddingLeft: 2 }}>{hint}</div>
       )}
     </div>
   );
@@ -129,10 +129,10 @@ function AssetItem({ asset, t }: Readonly<{
         <Image size={24} style={{ color: t.fgMuted, flexShrink: 0 }}/>
       )}
       <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ fontSize: 11, color: t.fg, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontFamily: t.mono }}>
+        <div style={{ fontSize: 13, color: t.fg, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontFamily: t.mono }}>
           {asset.filename}
         </div>
-        <div style={{ fontSize: 10, color: t.fgSub, fontFamily: t.mono }}>
+        <div style={{ fontSize: 12, color: t.fgSub, fontFamily: t.mono }}>
           {asset.path} · {formatBytes(asset.size)}
         </div>
       </div>
@@ -144,7 +144,7 @@ function AssetItem({ asset, t }: Readonly<{
           border: `1px solid ${copied ? t.success + '55' : t.border}`,
           background: copied ? t.bg : 'transparent',
           color: copied ? t.success : t.fgMuted,
-          fontSize: 10, cursor: 'pointer', fontFamily: t.mono, whiteSpace: 'nowrap',
+          fontSize: 12, cursor: 'pointer', fontFamily: t.mono, whiteSpace: 'nowrap',
         }}
       >
         {copied ? <Check size={10}/> : null}
@@ -257,7 +257,7 @@ export default function AssetsPanel() {
       </div>
 
       <DropZone
-        label={faviconSaved ? '✓ Favicon обновлён!' : 'Загрузить favicon'}
+        label={faviconSaved ? '✓ Иконка сайта обновлена!' : 'Загрузить иконку сайта (favicon)'}
         accept="image/png,image/svg+xml,image/x-icon,image/webp"
         onFiles={handleFaviconUpload}
         loading={faviconLoading}
@@ -268,7 +268,7 @@ export default function AssetsPanel() {
       <div style={{ height: 10 }} />
 
       <DropZone
-        label={logoSaved === 'light' ? '✓ Light logo обновлён!' : 'Загрузить light_logo'}
+        label={logoSaved === 'light' ? '✓ Логотип для светлой темы обновлён!' : 'Загрузить логотип для светлой темы'}
         accept="image/png,image/svg+xml,image/webp"
         onFiles={(files) => handleLogoUpload('light', files)}
         loading={lightLogoLoading}
@@ -279,7 +279,7 @@ export default function AssetsPanel() {
       <div style={{ height: 10 }} />
 
       <DropZone
-        label={logoSaved === 'dark' ? '✓ Dark logo обновлён!' : 'Загрузить dark_logo'}
+        label={logoSaved === 'dark' ? '✓ Логотип для тёмной темы обновлён!' : 'Загрузить логотип для тёмной темы'}
         accept="image/png,image/svg+xml,image/webp"
         onFiles={(files) => handleLogoUpload('dark', files)}
         loading={darkLogoLoading}
@@ -290,7 +290,7 @@ export default function AssetsPanel() {
       <div style={{
         marginTop: 10, padding: '8px 10px', borderRadius: 7,
         border: `1px solid ${t.border}`, background: t.surface,
-        fontSize: 10, color: t.fgSub, lineHeight: 1.55,
+        fontSize: 12, color: t.fgSub, lineHeight: 1.55,
       }}>
         Favicon используется только браузером для вкладок. В навигации отображается light_logo или dark_logo в зависимости от текущей темы; если вариант не задан, будет fallback на другой логотип или favicon.
       </div>
@@ -316,7 +316,7 @@ export default function AssetsPanel() {
 
       {assets.length > 0 && (
         <div style={{ marginTop: 14 }}>
-          <div style={{ fontSize: 10, color: t.fgSub, marginBottom: 8, fontFamily: t.mono }}>
+          <div style={{ fontSize: 12, color: t.fgSub, marginBottom: 8, fontFamily: t.mono }}>
             Загружено в этой сессии ({assets.length}):
           </div>
           {assets.map(a => <AssetItem key={a.filename} asset={a} t={t}/>)}
@@ -327,7 +327,7 @@ export default function AssetsPanel() {
         <div style={{
           marginTop: 12, padding: '8px 10px', borderRadius: 6,
           background: t.bg, border: `1px solid ${t.danger}44`,
-          color: t.danger, fontSize: 11,
+          color: t.danger, fontSize: 13,
           display: 'flex', gap: 6, alignItems: 'center',
         }}>
           ⚠ {error}

--- a/src/features/dev-panel/panels/ContactsPanel.tsx
+++ b/src/features/dev-panel/panels/ContactsPanel.tsx
@@ -56,7 +56,7 @@ function ContactRow({ contact, index, onChange, onDelete, t }: {
   const fieldStyle: React.CSSProperties = {
     flex: 1, padding: '5px 8px', borderRadius: 5,
     border: `1px solid ${t.border}`,
-    background: t.inpBg, color: t.fg, fontSize: 11,
+    background: t.inpBg, color: t.fg, fontSize: 14,
     outline: 'none', fontFamily: t.mono, minWidth: 0,
   };
 
@@ -64,15 +64,15 @@ function ContactRow({ contact, index, onChange, onDelete, t }: {
     <div style={{ border: `1px solid ${t.border}`, borderRadius: 8, marginBottom: 8, overflow: 'hidden' }}>
       <div style={{
         display: 'flex', alignItems: 'center', gap: 6,
-        padding: '6px 10px', background: t.surface,
+        padding: '8px 12px', background: t.surface,
         borderBottom: `1px solid ${t.border}`,
       }}>
-        <span style={{ fontSize: 10, color: t.fgSub, fontFamily: t.mono }}>#{index + 1}</span>
-        <span style={{ flex: 1, fontSize: 11, color: t.fg, fontWeight: 500 }}>
+        <span style={{ fontSize: 12, color: t.fgSub, fontFamily: t.mono }}>#{index + 1}</span>
+        <span style={{ flex: 1, fontSize: 14, color: t.fg, fontWeight: 500 }}>
           {contact.title || 'Без названия'}
         </span>
         <span style={{
-          fontSize: 9, padding: '1px 5px', borderRadius: 3,
+          fontSize: 11, padding: '1px 5px', borderRadius: 3,
           background: t.surfaceHov, color: t.fgMuted,
         }}>
           {contact.href.startsWith('mailto:') ? 'email' : 'external'}
@@ -83,10 +83,10 @@ function ContactRow({ contact, index, onChange, onDelete, t }: {
           onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.color = t.danger; }}
           onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.color = t.fgSub; }}
         >
-          <Trash2 size={11}/>
+          <Trash2 size={14}/>
         </button>
       </div>
-      <div style={{ padding: '8px 10px', display: 'flex', flexDirection: 'column', gap: 5 }}>
+      <div style={{ padding: '10px 12px', display: 'flex', flexDirection: 'column', gap: 8 }}>
         <div style={{ display: 'flex', gap: 6 }}>
           <input value={contact.title}    onChange={e => set('title',    e.target.value)} placeholder="Название (GitHub, Telegram...)" style={fieldStyle}/>
           <input value={contact.subtitle} onChange={e => set('subtitle', e.target.value)} placeholder="Подпись"                        style={fieldStyle}/>
@@ -168,20 +168,20 @@ export default function ContactsPanel() {
           onClick={addContact}
           style={{
             width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
-            padding: '9px', borderRadius: 7,
+            padding: '11px', borderRadius: 7,
             border: `1px dashed ${t.border}`,
             background: 'transparent', color: t.fgMuted,
-            fontSize: 11, cursor: 'pointer', fontFamily: t.mono,
+            fontSize: 14, cursor: 'pointer', fontFamily: t.mono,
           }}
           onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.borderColor = t.borderStrong; (e.currentTarget as HTMLButtonElement).style.color = t.fg; }}
           onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.borderColor = t.border;       (e.currentTarget as HTMLButtonElement).style.color = t.fgMuted; }}
         >
-          <Plus size={13}/> Добавить контакт
+          <Plus size={15}/> Добавить контакт
         </button>
       </div>
 
       {error && (
-        <div style={{ padding: '8px 12px', color: t.danger, fontSize: 11, display: 'flex', gap: 5 }}>
+        <div style={{ padding: '8px 12px', color: t.danger, fontSize: 14, display: 'flex', gap: 8 }}>
           <AlertCircle size={11}/> {error}
         </div>
       )}
@@ -193,10 +193,10 @@ export default function ContactsPanel() {
         <button
           onClick={load}
           style={{
-            display: 'flex', alignItems: 'center', gap: 5,
+            display: 'flex', alignItems: 'center', gap: 8,
             padding: '6px 11px', borderRadius: 7,
             border: `1px solid ${t.border}`, background: 'transparent', color: t.fgMuted,
-            fontSize: 11, cursor: 'pointer', fontFamily: t.mono,
+            fontSize: 14, cursor: 'pointer', fontFamily: t.mono,
           }}
         >
           Обновить
@@ -210,7 +210,7 @@ export default function ContactsPanel() {
             border: `1px solid ${saved ? t.success + '66' : t.borderStrong}`,
             background: saved ? savedBg : t.surfaceHov,
             color: saved ? t.success : t.fg,
-            fontSize: 11, fontWeight: 500, cursor: 'pointer', fontFamily: t.mono,
+            fontSize: 14, fontWeight: 500, cursor: 'pointer', fontFamily: t.mono,
           }}
         >
           {saving && <Loader2 size={11} style={{ animation: 'devSpinAnim 1s linear infinite' }}/>}

--- a/src/features/dev-panel/panels/DocsPanel.tsx
+++ b/src/features/dev-panel/panels/DocsPanel.tsx
@@ -11,7 +11,7 @@ import {
   FolderOpen, Plus, Trash2,
   ChevronRight, ChevronDown, FolderPlus, FilePlus,
   Loader2, Bold, Italic, Code, Link, Hash, List,
-  RefreshCw, Minus, Image, BarChart2, Table,
+  RefreshCw, Minus, Image, BarChart2, Table, Search,
   Columns, AlertCircle, Calculator, Footprints, LayoutGrid, Type,
   Edit3,
 } from 'lucide-react';
@@ -70,8 +70,15 @@ const parseName = (name: string) => {
   const icon = im?.[1] ?? null;
   const ai = im ? rest.slice(im[0].length) : rest;
   const sm = RE_PN_SLUG.exec(ai);
-  return { type, icon, title: sm ? sm[1].trim() : ai.trim(), slug: sm ? sm[2].trim() : null };
+  const rawTitle = sm ? sm[1].trim() : ai.trim();
+  const prettyTitle = rawTitle
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, ch => ch.toUpperCase());
+  return { type, icon, title: prettyTitle || rawTitle, slug: sm ? sm[2].trim() : null };
 };
+
 
 const buildTree = (flat: FlatEntry[]): TreeEntry[] => {
   const m = new Map<string,TreeEntry>();
@@ -387,7 +394,7 @@ function EntryModal({ cfg, existing, onClose, onDone, t }: {
     fontSize:12, outline:'none', fontFamily:t.mono, boxSizing:'border-box',
   };
   const lbS: React.CSSProperties = {
-    fontSize:9, color:t.fgSub, textTransform:'uppercase',
+    fontSize:12, color:t.fgSub, textTransform:'uppercase',
     letterSpacing:'0.07em', marginBottom:4, display:'block',
   };
   const idleLabel = isEdit ? 'Применить' : 'Создать';
@@ -421,7 +428,7 @@ function EntryModal({ cfg, existing, onClose, onDone, t }: {
           <input id="entry-slug" value={slug} onChange={e => { setSlug(e.target.value); setAuto(false); }} style={{...inp, flex:1}}/>
           <button
             onClick={() => { setAuto(true); setSlug(toSlug(title)); }}
-            style={{padding:'7px 10px', borderRadius:7, border:`1px solid ${t.border}`, background:t.surfaceHov, color:t.fgMuted, cursor:'pointer', fontSize:11, fontFamily:t.mono}}
+            style={{padding:'7px 10px', borderRadius:7, border:`1px solid ${t.border}`, background:t.surfaceHov, color:t.fgMuted, cursor:'pointer', fontSize:13, fontFamily:t.mono}}
           >↺</button>
         </div>
       </div>
@@ -453,7 +460,7 @@ function EntryModal({ cfg, existing, onClose, onDone, t }: {
         </div>
       )}
       <div style={{display:'flex', gap:8, marginTop:16}}>
-        <button onClick={onClose} style={{flex:1, padding:'8px', borderRadius:7, border:`1px solid ${t.border}`, background:'transparent', color:t.fgMuted, cursor:'pointer', fontSize:12, fontFamily:t.mono}}>Отмена</button>
+        <button onClick={onClose} style={{flex:1, padding:'8px', borderRadius:7, border:`1px solid ${t.border}`, background:'transparent', color:t.fgMuted, cursor:'pointer', fontSize:14, fontFamily:t.mono}}>Отмена</button>
         <button onClick={doSave} disabled={saving} style={{flex:1, padding:'8px', borderRadius:7, border:`1px solid ${t.borderStrong}`, background:t.surfaceHov, color:t.fg, cursor:'pointer', fontSize:12, fontWeight:600, fontFamily:t.mono}}>
           {saveBtnLabel}
         </button>
@@ -497,7 +504,7 @@ function BlockPicker({ onInsert, t }: { readonly onInsert: (c:string) => void; r
   const rs = (active?: boolean): React.CSSProperties => ({
     width:'100%', display:'flex', alignItems:'center', gap:7, padding:'6px 10px',
     borderRadius:5, border:'none', cursor:'pointer', textAlign:'left' as const,
-    background: active ? t.surfaceHov : 'transparent', color:t.fg, fontSize:11, fontFamily:t.mono,
+    background: active ? t.surfaceHov : 'transparent', color:t.fg, fontSize:13, fontFamily:t.mono,
     justifyContent:'space-between' as const,
   });
 
@@ -512,7 +519,7 @@ function BlockPicker({ onInsert, t }: { readonly onInsert: (c:string) => void; r
           padding:'3px 8px', height:22, borderRadius:5,
           border:`1px solid ${open ? t.borderStrong : t.border}`,
           background: open ? t.surfaceHov : 'transparent',
-          color: open ? t.fg : t.fgMuted, cursor:'pointer', fontSize:11, fontFamily:t.mono, gap:4,
+          color: open ? t.fg : t.fgMuted, cursor:'pointer', fontSize:13, fontFamily:t.mono, gap:4,
         }}
         onMouseEnter={e => { if (!open) { (e.currentTarget as HTMLButtonElement).style.background = t.surfaceHov; (e.currentTarget as HTMLButtonElement).style.color = t.fg; } }}
         onMouseLeave={e => { if (!open) { (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; (e.currentTarget as HTMLButtonElement).style.color = t.fgMuted; } }}
@@ -545,7 +552,7 @@ function BlockPicker({ onInsert, t }: { readonly onInsert: (c:string) => void; r
                 <button onClick={() => setSub(null)} style={{display:'flex', alignItems:'center', gap:4, padding:'5px 8px', border:'none', background:'transparent', color:t.fgMuted, cursor:'pointer', fontSize:10, fontFamily:t.mono, marginBottom:3}}>
                   <ChevronRight size={9} style={{transform:'rotate(180deg)'}}/> Назад
                 </button>
-                <div style={{fontSize:9, color:t.fgSub, padding:'0 8px 5px', fontWeight:700, textTransform:'uppercase', letterSpacing:'0.07em'}}>{sub.label}</div>
+                <div style={{fontSize:12, color:t.fgSub, padding:'0 8px 5px', fontWeight:700, textTransform:'uppercase', letterSpacing:'0.07em'}}>{sub.label}</div>
                 {sub.variants!.map((v, vi) => (
                   <button
                     key={v.label + vi}
@@ -614,8 +621,6 @@ function MarkdownEditor({ filePath, onClose, t }: { readonly filePath: string; r
   }, []);
 
   const fileName = filePath.split('/').pop()?.replace(/\.md$/, '') ?? '';
-  const isDark = t.bg === '#111112';
-
   useEffect(() => {
     setLoading(true);
     bridge.readFile(filePath)
@@ -718,17 +723,17 @@ function MarkdownEditor({ filePath, onClose, t }: { readonly filePath: string; r
   return (
     <div style={{flex:1, display:'flex', flexDirection:'column', overflow:'hidden', minHeight:0}}>
       <div style={{display:'flex', alignItems:'center', gap:6, padding:'6px 10px', borderBottom:`1px solid ${t.border}`, background:t.surface, flexShrink:0}}>
-        <button onClick={onClose} style={{display:'flex', alignItems:'center', gap:4, padding:'5px 9px', borderRadius:6, border:`1px solid ${t.border}`, background:'transparent', color:t.fgMuted, cursor:'pointer', fontSize:11, fontFamily:t.mono, flexShrink:0}}
+        <button onClick={onClose} style={{display:'flex', alignItems:'center', gap:4, padding:'5px 9px', borderRadius:6, border:`1px solid ${t.border}`, background:'transparent', color:t.fgMuted, cursor:'pointer', fontSize:13, fontFamily:t.mono, flexShrink:0}}
           onMouseEnter={e => (e.currentTarget as HTMLButtonElement).style.background = t.surfaceHov}
           onMouseLeave={e => (e.currentTarget as HTMLButtonElement).style.background = 'transparent'}
         >← Назад</button>
         <span style={{flex:1, fontSize:11, color:t.fg, fontFamily:t.mono, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap'}}>
           {fileName}{dirty && <span style={{color:t.warning, marginLeft:5}}>●</span>}
         </span>
-        <button onClick={save} style={{display:'flex', alignItems:'center', gap:6, padding:'5px 12px', borderRadius:6, border:`1px solid ${dirty ? t.borderStrong : t.border}`, background:dirty ? t.surfaceHov : 'transparent', color:dirty ? t.fg : t.fgMuted, cursor:'pointer', fontSize:11, fontFamily:t.mono, flexShrink:0, fontWeight:dirty ? 600 : 400}}>
+        <button onClick={save} style={{display:'flex', alignItems:'center', gap:6, padding:'5px 12px', borderRadius:6, border:`1px solid ${dirty ? t.borderStrong : t.border}`, background:dirty ? t.surfaceHov : 'transparent', color:dirty ? t.fg : t.fgMuted, cursor:'pointer', fontSize:13, fontFamily:t.mono, flexShrink:0, fontWeight:dirty ? 600 : 400}}>
           {saving && <Loader2 size={11} style={{animation:'devSpinAnim 1s linear infinite'}}/>}
           Сохранить
-          <span style={{fontSize:9, color:t.fgSub, background:t.inpBg, border:`1px solid ${t.border}`, borderRadius:3, padding:'1px 4px', fontFamily:t.mono}}>Ctrl+S</span>
+          <span style={{fontSize:12, color:t.fgSub, background:t.inpBg, border:`1px solid ${t.border}`, borderRadius:3, padding:'1px 4px', fontFamily:t.mono}}>Ctrl+S</span>
         </button>
       </div>
 
@@ -748,7 +753,7 @@ function MarkdownEditor({ filePath, onClose, t }: { readonly filePath: string; r
               {k:'robots', l:'Robots'},
             ] as Array<{k: keyof FM; l: string; sp?: boolean; tp?: string}>).map(f => (
               <div key={f.k} style={{gridColumn: f.sp ? '1 / -1' : 'auto'}}>
-                <div style={{fontSize:9, color:t.fgSub, marginBottom:2, textTransform:'uppercase', letterSpacing:'0.06em'}}>{f.l}</div>
+                <div style={{fontSize:12, color:t.fgSub, marginBottom:2, textTransform:'uppercase', letterSpacing:'0.06em'}}>{f.l}</div>
                 <input
                   type={f.tp ?? 'text'}
                   value={fm[f.k]}
@@ -784,7 +789,7 @@ function MarkdownEditor({ filePath, onClose, t }: { readonly filePath: string; r
         <div style={{width:1, height:14, background:t.border, margin:'0 3px'}}/>
         <BlockPicker onInsert={insertAtCursor} t={t}/>
         <div style={{flex:1}}/>
-        <span style={{fontSize:10, color:t.fgSub}}>{body.trim().split(/\s+/).filter(Boolean).length} слов</span>
+        <span style={{fontSize:12, color:t.fgSub}}>{body.trim().split(/\s+/).filter(Boolean).length} слов</span>
       </div>
 
       <textarea
@@ -796,8 +801,8 @@ function MarkdownEditor({ filePath, onClose, t }: { readonly filePath: string; r
         placeholder="Начните писать..."
         style={{
           flex:1, padding:'12px 14px', border:'none',
-          background: isDark ? '#0d0d0e' : '#eceae5',
-          color: isDark ? '#e2e8f0' : '#1e293b',
+          background: t.inpBg,
+          color: t.editorFg,
           fontSize:12,
           fontFamily:'ui-monospace, "Cascadia Code", "Fira Code", monospace',
           lineHeight:1.75, resize:'none', outline:'none',
@@ -838,15 +843,14 @@ function TreeNode({ entry, onCreate, onDelete, onEdit, onSelect, onDrop,
   const isActive = entry.path === selectedPath;
   const isDragOver = dragOverPath === entry.path;
   const p = entry.parsed;
-  const typeDot: Record<string,string> = { N:'#22c55e', C:'#14b8a6', A:'#f59e0b' };
 
   const actionBtn = (ico: React.ReactNode, tip: string, fn: () => void, danger?: boolean) => (
     <button key={tip} title={tip}
       onClick={e => { e.stopPropagation(); fn(); }}
-      style={{width:28, height:28, borderRadius:5, border:'none', flexShrink:0, display:'flex', alignItems:'center', justifyContent:'center', background:t.surfaceHov, color:danger ? t.danger : t.fgMuted, cursor:'pointer'}}
+      style={{height:32, borderRadius:6, border:`1px solid ${t.border}`, padding:'0 8px', flexShrink:0, display:'flex', alignItems:'center', gap:5, justifyContent:'center', background:t.surfaceHov, color:danger ? t.danger : t.fgMuted, cursor:'pointer', fontSize:13, fontFamily:t.mono}}
       onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.color = danger ? t.danger : t.fg; (e.currentTarget as HTMLButtonElement).style.background = danger ? 'rgba(239,68,68,0.1)' : t.surfaceHov; }}
       onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.color = danger ? t.danger : t.fgMuted; (e.currentTarget as HTMLButtonElement).style.background = t.surfaceHov; }}
-    >{ico}</button>
+    >{ico}<span>{tip}</span></button>
   );
 
   const nodeBg      = getNodeBackground(isDragOver, isDir, isActive, hov, t);
@@ -872,25 +876,23 @@ function TreeNode({ entry, onCreate, onDelete, onEdit, onSelect, onDrop,
         style={{
           display:'flex', alignItems:'center', gap:5, cursor:'grab', userSelect:'none',
           width:'100%', textAlign:'left',
-          padding:`4px 8px 4px ${8 + entry.depth * 14}px`,
-          borderRadius:6, border:'none',
+          padding:`5px 10px 5px ${12 + entry.depth * 14}px`,
+          borderRadius:7, border:'none',
           background: nodeBg,
           outline: nodeOutline,
           outlineOffset:-1, minHeight:28, transition:'background 0.1s',
         }}
       >
-        <span style={{width:14, height:14, flexShrink:0, display:'flex', alignItems:'center', justifyContent:'center', color:t.fgSub}}>
+        <span style={{width:14, height:14, flexShrink:0, display:'flex', alignItems:'center', justifyContent:'center', color:t.fgSub, opacity:isDir?1:0.55}}>
           {chevronIcon}
         </span>
-        {p.type && <span style={{width:7, height:7, borderRadius:'50%', flexShrink:0, background:typeDot[p.type] ?? t.fgSub}}/>}
-        {p.icon && <span style={{fontSize:9, color:t.fgSub, flexShrink:0, fontFamily:t.mono, maxWidth:60, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap'}}>{p.icon}</span>}
-        <span style={{fontSize:12, color:t.fg, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap', flex:1, fontWeight}}>
+        <span style={{fontSize:16, color:t.fg, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap', flex:1, fontWeight}}>
           {p.title || entry.name}
         </span>
         {hov && (
           <div
             role="toolbar"
-            style={{display:'flex', gap:3, flexShrink:0}}
+            style={{display:'flex', gap:6, flexShrink:0}}
             onClick={e => e.stopPropagation()}
             onKeyDown={e => e.stopPropagation()}
           >
@@ -902,7 +904,7 @@ function TreeNode({ entry, onCreate, onDelete, onEdit, onSelect, onDrop,
         )}
       </button>
       {isDir && expanded && entry.children.length > 0 && (
-        <div style={{marginLeft: 8 + entry.depth * 14 + 7, borderLeft:`1px solid ${t.border}`}}>
+        <div style={{marginLeft: 13 + entry.depth * 14, borderLeft:`1px solid ${t.border}`, paddingLeft: 8}}>
           {entry.children.map(c => (
             <TreeNode key={c.path} entry={c} onCreate={onCreate} onDelete={onDelete}
               onEdit={onEdit} onSelect={onSelect} onDrop={onDrop}
@@ -913,6 +915,24 @@ function TreeNode({ entry, onCreate, onDelete, onEdit, onSelect, onDrop,
       )}
     </div>
   );
+}
+
+
+function filterTreeByQuery(entries: TreeEntry[], query: string): TreeEntry[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return entries;
+
+  const walk = (items: TreeEntry[]): TreeEntry[] => items
+    .map(item => {
+      const title = (item.parsed.title || item.name).toLowerCase();
+      const matchesSelf = title.includes(q) || item.path.toLowerCase().includes(q);
+      const children = walk(item.children);
+      if (matchesSelf || children.length > 0) return { ...item, children };
+      return null;
+    })
+    .filter(Boolean) as TreeEntry[];
+
+  return walk(entries);
 }
 
 function countFiles(entries: TreeEntry[]): number {
@@ -931,6 +951,7 @@ export default function DocsPanel() {
   const [toDelete, setToDelete]         = useState<TreeEntry|null>(null);
   const [dragOverPath, setDragOverPath] = useState<string|null>(null);
   const [moving, setMoving]         = useState(false);
+  const [query, setQuery]           = useState('');
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -1015,22 +1036,23 @@ export default function DocsPanel() {
     }
   }, [tree, selected, load]);
 
+  const visibleTree = filterTreeByQuery(tree, query);
   const fileCount = countFiles(tree);
 
   const renderTreeContent = () => {
     if (loading) return (
       <div style={{display:'flex', alignItems:'center', justifyContent:'center', gap:8, padding:24, color:t.fgMuted}}>
         <Loader2 size={14} style={{animation:'devSpinAnim 1s linear infinite'}}/>
-        <span style={{fontSize:12}}>Загрузка...</span>
+        <span style={{fontSize:14}}>Загрузка...</span>
       </div>
     );
-    if (tree.length === 0) return (
+    if (visibleTree.length === 0) return (
       <div style={{display:'flex', flexDirection:'column', alignItems:'center', gap:8, padding:28, color:t.fgMuted, textAlign:'center'}}>
         <FolderOpen size={28} style={{opacity:0.3}}/>
-        <div style={{fontSize:12}}>Docs/ пуста. Создай Секция</div>
+        <div style={{fontSize:14}}>{query ? 'Ничего не найдено' : 'Docs/ пуста. Создай Секция'}</div>
       </div>
     );
-    return tree.map(e => (
+    return visibleTree.map(e => (
       <TreeNode key={e.path} entry={e} onCreate={cfg => setModalCfg({cfg})}
         onDelete={setToDelete} onEdit={handleEdit}
         onSelect={p => setSelected(p)} onDrop={handleDrop}
@@ -1053,11 +1075,23 @@ export default function DocsPanel() {
     <div style={{flex:1, display:'flex', flexDirection:'column', overflow:'hidden'}}>
       <div style={{display:'flex', alignItems:'center', gap:8, padding:'7px 10px', borderBottom:`1px solid ${t.border}`, flexShrink:0, background:t.surface}}>
         <button onClick={() => setModalCfg({cfg:{parentPath:'Docs', entryType:'N'}})} style={{display:'flex', alignItems:'center', gap:5, padding:'6px 12px', borderRadius:7, border:`1px solid ${t.borderStrong}`, background:t.surfaceHov, color:t.fg, fontSize:11, fontWeight:500, cursor:'pointer', fontFamily:t.mono}}>
-          <Plus size={12}/> Секция
+          <Plus size={13}/> Секция
+        </button>
+        <button onClick={() => setModalCfg({cfg:{parentPath:'Docs', entryType:'A'}})} style={{display:'flex', alignItems:'center', gap:5, padding:'7px 12px', borderRadius:7, border:`1px solid ${t.border}`, background:'transparent', color:t.fg, fontSize:13, fontWeight:500, cursor:'pointer', fontFamily:t.mono}}>
+          <FilePlus size={13}/> Страница
         </button>
         <div style={{flex:1}}/>
+        <div style={{display:'flex', alignItems:'center', gap:6, minWidth:220, maxWidth:340, width:'36%'}}>
+          <Search size={12} style={{color:t.fgSub}}/>
+          <input
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="Поиск документа..."
+            style={{width:'100%', padding:'6px 8px', borderRadius:6, border:`1px solid ${t.border}`, background:t.inpBg, color:t.fg, fontSize:14, fontFamily:t.mono, outline:'none'}}
+          />
+        </div>
         {moving && <Loader2 size={12} style={{color:t.fgMuted, animation:'devSpinAnim 1s linear infinite'}}/>}
-        <button onClick={load} style={{display:'flex', alignItems:'center', gap:4, padding:'6px 10px', borderRadius:6, border:`1px solid ${t.border}`, background:'transparent', color:t.fgMuted, cursor:'pointer', fontSize:11, fontFamily:t.mono}}
+        <button onClick={load} style={{display:'flex', alignItems:'center', gap:4, padding:'6px 10px', borderRadius:6, border:`1px solid ${t.border}`, background:'transparent', color:t.fgMuted, cursor:'pointer', fontSize:13, fontFamily:t.mono}}
           onMouseEnter={e => (e.currentTarget as HTMLButtonElement).style.background = t.surfaceHov}
           onMouseLeave={e => (e.currentTarget as HTMLButtonElement).style.background = 'transparent'}
         >
@@ -1065,7 +1099,7 @@ export default function DocsPanel() {
         </button>
       </div>
 
-      <div style={{padding:'4px 12px', fontSize:9, color:t.fgSub, background:t.surface, borderBottom:`1px solid ${t.border}`}}>
+      <div style={{padding:'4px 12px', fontSize:12, color:t.fgSub, background:t.surface, borderBottom:`1px solid ${t.border}`}}>
         Перетащи страницу или категорию в другую папку
       </div>
 
@@ -1079,7 +1113,7 @@ export default function DocsPanel() {
         {renderTreeContent()}
       </section>
 
-      <div style={{padding:'5px 10px', borderTop:`1px solid ${t.border}`, display:'flex', alignItems:'center', justifyContent:'space-between', fontSize:10, color:t.fgSub, background:t.surface, flexShrink:0}}>
+      <div style={{padding:'5px 10px', borderTop:`1px solid ${t.border}`, display:'flex', alignItems:'center', justifyContent:'space-between', fontSize:12, color:t.fgSub, background:t.surface, flexShrink:0}}>
         <span>{fileCount} страниц</span>
         <span style={{fontFamily:t.mono}}>Docs/</span>
       </div>

--- a/src/features/dev-panel/panels/SitePanel.tsx
+++ b/src/features/dev-panel/panels/SitePanel.tsx
@@ -52,7 +52,7 @@ function ModeButton({
       onClick={onClick}
       style={{
         display: 'flex', alignItems: 'flex-start', gap: 12,
-        padding: '12px 14px', borderRadius: 9,
+        padding: '14px 16px', borderRadius: 9,
         border: `1px solid ${active ? t.borderStrong : t.border}`,
         background: active ? t.accentSoft : 'transparent',
         color: active ? t.fg : t.fgMuted,
@@ -65,9 +65,9 @@ function ModeButton({
       <div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 3 }}>
           {icon}
-          <span style={{ fontSize: 12, fontWeight: 600 }}>{label}</span>
+          <span style={{ fontSize: 14, fontWeight: 600 }}>{label}</span>
         </div>
-        <div style={{ fontSize: 10, color: t.fgSub, lineHeight: 1.5 }}>{description}</div>
+        <div style={{ fontSize: 12, color: t.fgSub, lineHeight: 1.5 }}>{description}</div>
       </div>
     </button>
   );
@@ -169,18 +169,18 @@ export default function SitePanel() {
   const handleToggleLanding = (value: boolean) =>
     applyConfigChange(
       { ...config, useLanding: value },
-      value ? 'Лендинг включён' : 'Welcome.md включён',
+      value ? 'Режим: лендинг' : 'Режим: документация',
     );
 
   const handleToggleDotWave = (value: boolean) =>
     applyConfigChange(
       { ...config, showDotWaveBackground: value },
-      value ? 'DotWave фон включён' : 'DotWave фон отключён',
+      value ? 'Фон шапки включён' : 'Фон шапки отключён',
     );
 
   if (loading) {
     return (
-      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, color: t.fgSub, fontSize: 12 }}>
+      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, color: t.fgSub, fontSize: 14 }}>
         <Loader2 size={14} style={{ animation: 'devSpin 1s linear infinite' }} /> Загрузка...
       </div>
     );
@@ -194,7 +194,7 @@ export default function SitePanel() {
       {/* Заголовок */}
       <div style={{
         display: 'flex', alignItems: 'center', gap: 6,
-        fontSize: 9, fontWeight: 700, color: t.fgSub,
+        fontSize: 11, fontWeight: 700, color: t.fgSub,
         textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 12,
       }}>
         ГЛАВНАЯ СТРАНИЦА
@@ -202,12 +202,12 @@ export default function SitePanel() {
 
       {/* Описание */}
       <div style={{
-        fontSize: 11, color: t.fgMuted, lineHeight: 1.55,
-        marginBottom: 16, padding: '8px 10px',
+        fontSize: 13, color: t.fgMuted, lineHeight: 1.55,
+        marginBottom: 16, padding: '10px 12px',
         borderRadius: 7, border: `1px solid ${t.border}`,
         background: t.surface,
       }}>
-        Выберите, что отображается на главной странице (<code style={{ fontFamily: t.mono, fontSize: 10 }}>/</code>).
+        Выберите, что отображается на главной странице (<code style={{ fontFamily: t.mono, fontSize: 12 }}>/</code>).
         Изменение вступит в силу при следующем обращении к странице.
       </div>
 
@@ -217,18 +217,18 @@ export default function SitePanel() {
           active={!config.useLanding}
           saving={saving}
           onClick={() => handleToggleLanding(false)}
-          icon={<FileText size={13} style={{ color: config.useLanding ? t.fgMuted : t.fg }} />}
+          icon={<FileText size={15} style={{ color: config.useLanding ? t.fgMuted : t.fg }} />}
           label="Welcome.md"
-          description={<>Стандартная документация. Файл <code style={{ fontFamily: t.mono }}>Docs/welcome.md</code> отображается как главная страница.</>}
+          description={<>Показывать обычную главную документации из файла <code style={{ fontFamily: t.mono }}>Docs/welcome.md</code>.</>}
           t={t}
         />
         <ModeButton
           active={config.useLanding}
           saving={saving}
           onClick={() => handleToggleLanding(true)}
-          icon={<LayoutTemplate size={13} style={{ color: config.useLanding ? t.fg : t.fgMuted }} />}
+          icon={<LayoutTemplate size={15} style={{ color: config.useLanding ? t.fg : t.fgMuted }} />}
           label="Лендинг"
-          description={<>Визуальная посадочная страница из <code style={{ fontFamily: t.mono }}>GeneralPage.tsx</code>. Welcome.md игнорируется.</>}
+          description={<>Показывать лендинг-страницу. В этом режиме <code style={{ fontFamily: t.mono }}>Welcome.md</code> не используется.</>}
           t={t}
         />
       </div>
@@ -237,9 +237,9 @@ export default function SitePanel() {
       {saving && (
         <div style={{
           display: 'flex', alignItems: 'center', gap: 6,
-          fontSize: 11, color: t.fgMuted, marginBottom: 10,
+          fontSize: 13, color: t.fgMuted, marginBottom: 10,
         }}>
-          <Loader2 size={11} style={{ animation: 'devSpin 1s linear infinite' }} />
+          <Loader2 size={13} style={{ animation: 'devSpin 1s linear infinite' }} />
           Сохранение...
         </div>
       )}
@@ -247,13 +247,13 @@ export default function SitePanel() {
       {/* Ошибка */}
       {error && (
         <div style={{
-          padding: '8px 10px', borderRadius: 6,
+          padding: '10px 12px', borderRadius: 6,
           background: t.bg, border: `1px solid ${t.danger}44`,
-          color: t.danger, fontSize: 11,
+          color: t.danger, fontSize: 13,
           display: 'flex', gap: 6, alignItems: 'center',
           marginBottom: 10,
         }}>
-          <AlertCircle size={12} /> {error}
+          <AlertCircle size={14} /> {error}
         </div>
       )}
 
@@ -266,8 +266,8 @@ export default function SitePanel() {
         borderRadius: 7, border: `1px solid ${t.border}`, background: t.surface,
       }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          <span style={{ fontSize: 11, color: t.fgMuted, fontWeight: 600 }}>DotWave фон в шапке документа</span>
-          <span style={{ fontSize: 10, color: t.fgSub }}>Если выключить, фон будет как у навигации.</span>
+          <span style={{ fontSize: 13, color: t.fgMuted, fontWeight: 600 }}>Фон в шапке страницы</span>
+          <span style={{ fontSize: 12, color: t.fgSub }}>Если выключить, шапка станет спокойнее и ближе к фону навигации.</span>
         </div>
         <button
           disabled={saving}
@@ -278,7 +278,7 @@ export default function SitePanel() {
             color: t.fgMuted,
             borderRadius: 6,
             padding: '5px 9px',
-            fontSize: 10,
+            fontSize: 12,
             fontFamily: t.mono,
             cursor: saving ? 'not-allowed' : 'pointer',
             opacity: saving ? 0.7 : 1,
@@ -290,12 +290,12 @@ export default function SitePanel() {
 
       {/* Текущее состояние */}
       <div style={{
-        fontSize: 10, color: t.fgSub,
+        fontSize: 12, color: t.fgSub,
         display: 'flex', alignItems: 'center', justifyContent: 'space-between',
       }}>
         <span>
           Сейчас: <strong style={{ color: t.fgMuted }}>
-            {config.useLanding ? 'Лендинг' : 'Welcome.md'} · DotWave: {dotWaveEnabled ? 'вкл' : 'выкл'}
+            {config.useLanding ? 'Лендинг' : 'Документация'} · Фон шапки: {dotWaveEnabled ? 'вкл' : 'выкл'}
           </strong>
         </span>
         <button
@@ -304,7 +304,7 @@ export default function SitePanel() {
             display: 'flex', alignItems: 'center', gap: 4,
             padding: '4px 8px', borderRadius: 5,
             border: `1px solid ${t.border}`, background: 'transparent',
-            color: t.fgMuted, fontSize: 10, cursor: 'pointer', fontFamily: t.mono,
+            color: t.fgMuted, fontSize: 12, cursor: 'pointer', fontFamily: t.mono,
           }}
         >
           <RefreshCw size={9} /> Обновить
@@ -313,35 +313,35 @@ export default function SitePanel() {
 
       {/* Подсказка о перезагрузке */}
       <div style={{
-        marginTop: 16, padding: '8px 10px', borderRadius: 7,
+        marginTop: 16, padding: '10px 12px', borderRadius: 7,
         border: `1px solid ${t.border}`, background: t.surface,
-        fontSize: 10, color: t.fgSub, lineHeight: 1.55,
+        fontSize: 12, color: t.fgSub, lineHeight: 1.55,
       }}>
-        💡 После изменения режима в dev-режиме достаточно обновить страницу (<code style={{ fontFamily: t.mono }}>F5</code>).
-        В продакшне потребуется пересборка.
+        💡 После изменения режима обновите страницу сайта (<code style={{ fontFamily: t.mono }}>F5</code>).
+        В production-окружении может понадобиться пересборка.
       </div>
 
       <div style={{ height: 1, background: t.border, margin: '12px 0' }} />
 
       {/* Цвета тем */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 9, fontWeight: 700, color: t.fgSub, textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 8 }}>
-        ЦВЕТА ТЕМ
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, fontWeight: 700, color: t.fgSub, textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 8 }}>
+        ЦВЕТА САЙТА
       </div>
       <div style={{
-        marginBottom: 10, padding: '8px 10px', borderRadius: 7,
+        marginBottom: 10, padding: '10px 12px', borderRadius: 7,
         border: `1px solid ${t.border}`, background: t.surface,
-        fontSize: 10, color: t.fgMuted, lineHeight: 1.55,
+        fontSize: 12, color: t.fgMuted, lineHeight: 1.55,
       }}>
-        Здесь можно менять ВСЕ токены цветов. У каждого поля указано, где этот цвет используется.
+        Здесь можно настроить цвета светлой и тёмной тем. У каждого параметра есть подсказка — где он применяется.
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 8, maxHeight: 330, overflowY: 'auto', paddingRight: 2 }} className="adm-scroll">
         {(Object.keys(THEME_COLOR_META) as ThemeColorKey[]).map((key) => (
           <div key={key} style={{ border: `1px solid ${t.border}`, borderRadius: 8, padding: 8, background: t.surface }}>
-            <div style={{ fontSize: 11, color: t.fg, fontWeight: 600 }}>{THEME_COLOR_META[key].label}</div>
-            <div style={{ fontSize: 10, color: t.fgSub, margin: '2px 0 6px' }}>{THEME_COLOR_META[key].usage}</div>
+            <div style={{ fontSize: 13, color: t.fg, fontWeight: 600 }}>{THEME_COLOR_META[key].label}</div>
+            <div style={{ fontSize: 12, color: t.fgSub, margin: '2px 0 6px' }}>{THEME_COLOR_META[key].usage}</div>
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 6 }}>
-              <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 10, color: t.fgMuted }}>
-                Dark ({key})
+              <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: t.fgMuted }}>
+                Тёмная тема ({key})
                 <div style={{ display: 'flex', gap: 4 }}>
                   <input
                     type="color"
@@ -353,12 +353,12 @@ export default function SitePanel() {
                     type="text"
                     value={themeColors.dark[key]}
                     onChange={e => setThemeColors(prev => ({ dark: { ...prev.dark, [key]: e.target.value }, light: prev.light }))}
-                    style={{ flex: 1, height: 28, background: t.bg, border: `1px solid ${t.border}`, borderRadius: 6, color: t.fgMuted, padding: '0 8px', fontSize: 10, fontFamily: t.mono }}
+                    style={{ flex: 1, height: 28, background: t.bg, border: `1px solid ${t.border}`, borderRadius: 6, color: t.fgMuted, padding: '0 8px', fontSize: 12, fontFamily: t.mono }}
                   />
                 </div>
               </label>
-              <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 10, color: t.fgMuted }}>
-                Light ({key})
+              <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: t.fgMuted }}>
+                Светлая тема ({key})
                 <div style={{ display: 'flex', gap: 4 }}>
                   <input
                     type="color"
@@ -370,7 +370,7 @@ export default function SitePanel() {
                     type="text"
                     value={themeColors.light[key]}
                     onChange={e => setThemeColors(prev => ({ dark: prev.dark, light: { ...prev.light, [key]: e.target.value } }))}
-                    style={{ flex: 1, height: 28, background: t.bg, border: `1px solid ${t.border}`, borderRadius: 6, color: t.fgMuted, padding: '0 8px', fontSize: 10, fontFamily: t.mono }}
+                    style={{ flex: 1, height: 28, background: t.bg, border: `1px solid ${t.border}`, borderRadius: 6, color: t.fgMuted, padding: '0 8px', fontSize: 12, fontFamily: t.mono }}
                   />
                 </div>
               </label>
@@ -382,26 +382,26 @@ export default function SitePanel() {
         <button
           onClick={saveThemeColors}
           style={{
-            flex: 1, borderRadius: 8, padding: '8px 10px',
+            flex: 1, borderRadius: 8, padding: '10px 12px',
             border: `1px solid ${t.borderStrong}`,
             background: t.accentSoft,
             color: t.fg,
-            fontSize: 11, fontFamily: t.mono, cursor: 'pointer',
+            fontSize: 13, fontFamily: t.mono, cursor: 'pointer',
           }}
         >
-          Применить
+          Сохранить цвета
         </button>
         <button
           onClick={resetThemeColors}
           style={{
-            flex: 1, borderRadius: 8, padding: '8px 10px',
+            flex: 1, borderRadius: 8, padding: '10px 12px',
             border: `1px solid ${t.border}`,
             background: 'transparent',
             color: t.fgMuted,
-            fontSize: 11, fontFamily: t.mono, cursor: 'pointer',
+            fontSize: 13, fontFamily: t.mono, cursor: 'pointer',
           }}
         >
-          Сбросить
+          Вернуть стандартные
         </button>
       </div>
     </div>

--- a/src/features/dev-panel/useDevBridge.ts
+++ b/src/features/dev-panel/useDevBridge.ts
@@ -7,7 +7,11 @@
 
 import { useEffect, useState } from 'react';
 
-const WS_URL = 'ws://127.0.0.1:7777';
+const resolveWsUrl = (): string => {
+  if (typeof globalThis.location === 'undefined') return 'ws://127.0.0.1:7777';
+  const proto = globalThis.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${proto}//${globalThis.location.hostname}:7777`;
+};
 
 export type BridgeStatus = 'connecting' | 'connected' | 'disconnected' | 'error';
 
@@ -59,7 +63,7 @@ function connect() {
   broadcast('connecting');
 
   try {
-    ws = new WebSocket(WS_URL);
+    ws = new WebSocket(resolveWsUrl());
   } catch {
     broadcast('error');
     scheduleReconnect();
@@ -93,7 +97,12 @@ function connect() {
     scheduleReconnect();
   };
 
-  ws.onerror = () => { broadcast('error'); };
+  ws.onerror = () => {
+    broadcast('error');
+    if (ws?.readyState === WebSocket.OPEN || ws?.readyState === WebSocket.CONNECTING) {
+      ws.close();
+    }
+  };
 }
 
 function scheduleReconnect() {


### PR DESCRIPTION
### Motivation
- Improve readability and consistency across dev-panel UI by adjusting paddings, font sizes and button layouts. 
- Make document management more usable by normalizing titles and adding a search/filter for the docs tree. 
- Harden the dev bridge connection so it works reliably under both `http` and `https` and handles socket errors cleanly.

### Description
- Visual polish across panels (`DevPanel`, `AssetsPanel`, `ContactsPanel`, `DocsPanel`, `SitePanel`) including adjusted paddings, font sizes, button shapes, labels and localized copy to improve clarity. 
- Docs improvements: `parseName` now produces a prettified title (replacing dashes/underscores and capitalizing words), and a `filterTreeByQuery` + search input were added to filter the docs tree. Tree node visuals, actions and spacing were refined. 
- Assets/Contacts: updated DropZone text, item font sizes and copy button styling for clearer feedback. 
- SitePanel: clarified labels and descriptions, adjusted controls for theme colors and landing mode, and refined saving/error UI. 
- Bridge/network: replaced hardcoded WS URL with `resolveWsUrl()` that chooses `ws:`/`wss:` based on page protocol, and improved `ws.onerror` handling to close the socket on error.

### Testing
- Performed TypeScript type-checking with `tsc` which completed without errors. 
- Ran project build (`yarn build`) as a smoke check which succeeded. 
- Ran linters (`eslint`) against modified files and fixed reported issues, with no remaining lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12b649da6c832fba902c9709cd5f60)