### PR TITLE
Fix mobile CodeBlock menu, inline images, TOC glowing and navigation chrome

### DIFF
--- a/src/features/docs/components/AskAIButton.tsx
+++ b/src/features/docs/components/AskAIButton.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { Copy, Check, ChevronDown, Sparkles } from 'lucide-react';
 
 interface AskAIButtonProps {
@@ -79,19 +80,38 @@ const AskAIButton: React.FC<AskAIButtonProps> = ({
   const [copied,    setCopied]    = useState(false);
   const [hoveredId, setHoveredId] = useState<string | null>(null);
   const ref = useRef<HTMLDivElement>(null);
+  const popupRef = useRef<HTMLDivElement>(null);
+  const [menuPos, setMenuPos] = useState({ top: 0, left: 0 });
   const t   = getTheme(isDark);
 
   useEffect(() => {
     if (!open) return;
     const onDown = (e: MouseEvent) => {
       const target = e.target instanceof Node ? e.target : null;
-      if (ref.current && !ref.current.contains(target)) setOpen(false);
+      if (
+        (ref.current && ref.current.contains(target)) ||
+        (popupRef.current && popupRef.current.contains(target))
+      ) return;
+      setOpen(false);
     };
     document.addEventListener('mousedown', onDown);
     return () => document.removeEventListener('mousedown', onDown);
   }, [open]);
 
   const getPageUrl = () => globalThis.location.href;
+
+  const toggleOpen = () => {
+    if (open) { setOpen(false); return; }
+    const rect = ref.current?.getBoundingClientRect();
+    if (rect) {
+      const width = 200;
+      setMenuPos({
+        top: rect.bottom + 7,
+        left: Math.max(8, Math.min(rect.right - width, window.innerWidth - width - 8)),
+      });
+    }
+    setOpen(true);
+  };
 
   const handleProviderClick = (p: typeof PROVIDERS[0]) => {
     globalThis.open(p.getUrl(pageTitle, getPageUrl()), '_blank', 'noopener,noreferrer');
@@ -116,7 +136,7 @@ const AskAIButton: React.FC<AskAIButtonProps> = ({
   return (
     <div ref={ref} style={{ position: 'relative', display: 'inline-block' }}>
       <button
-        onClick={() => setOpen(v => !v)}
+        onClick={toggleOpen}
         onMouseEnter={e => (e.currentTarget.style.background = t.btnHov)}
         onMouseLeave={e => (e.currentTarget.style.background = open ? t.btnHov : t.btnBg)}
         style={{
@@ -148,11 +168,11 @@ const AskAIButton: React.FC<AskAIButtonProps> = ({
         />
       </button>
 
-      {open && (
-        <div style={{
-          position: 'absolute',
-          top: 'calc(100% + 7px)',
-          right: 0,
+      {open && createPortal(
+        <div ref={popupRef} style={{
+          position: 'fixed',
+          top: menuPos.top,
+          left: menuPos.left,
           width: '200px',
           background: t.popupBg,
           border: `1px solid ${t.border}`,
@@ -232,7 +252,8 @@ const AskAIButton: React.FC<AskAIButtonProps> = ({
             }
             {copied ? 'Скопировано!' : 'Копировать HTML'}
           </button>
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   );

--- a/src/features/docs/components/AskAIButton.tsx
+++ b/src/features/docs/components/AskAIButton.tsx
@@ -158,7 +158,7 @@ const AskAIButton: React.FC<AskAIButtonProps> = ({
           border: `1px solid ${t.border}`,
           borderRadius: '10px',
           boxShadow,
-          zIndex: 200,
+          zIndex: 100020,
           overflow: 'hidden',
           animation: 'askAiIn 0.13s ease',
         }}>

--- a/src/features/general/components/GeneralPage.tsx
+++ b/src/features/general/components/GeneralPage.tsx
@@ -1409,7 +1409,7 @@ const LandingContent: React.FC = () => {
         }
       `}</style>
 
-      <Navigation />
+      <Navigation floatingChrome />
 
       {/* Герой */}
       <section style={{

--- a/src/features/navigation/components/Navigation.tsx
+++ b/src/features/navigation/components/Navigation.tsx
@@ -686,22 +686,14 @@ const NavPanelContent: React.FC<{
 // ─── Вспомогательные функции для ToC ─────────────────────────────────────────
 
 function tocBorderColor(isActive: boolean, glowOp: number, isDark: boolean, accent: string): string {
-  if (isActive)   return isDark ? `color-mix(in srgb, ${accent} 72%, white 28%)` : accent;
-  if (glowOp > 0) return isDark ? `rgba(255,255,255,${glowOp * 0.55})` : `rgba(0,0,0,${glowOp * 0.28})`;
+  if (isActive)   return accent;
+  if (glowOp > 0) return isDark ? `rgba(255,255,255,${glowOp})` : `rgba(0,0,0,${glowOp})`;
   return 'transparent';
 }
 
 function tocShadow(isActive: boolean, glowOp: number, isDark: boolean, accent: string): string {
-  if (isActive) {
-    return isDark
-      ? `inset 0 0 0 1px ${accent}55, 0 0 18px ${accent}55, 0 0 36px ${accent}2f`
-      : `inset 0 0 0 1px ${accent}33, 0 0 18px ${accent}22`;
-  }
-  if (glowOp > 0) {
-    return isDark
-      ? `inset 0 0 0 1px rgba(255,255,255,${glowOp * 0.16}), 0 0 14px rgba(255,255,255,${glowOp * 0.08})`
-      : `inset 0 0 0 1px rgba(0,0,0,${glowOp * 0.08})`;
-  }
+  if (isActive)   return `inset 3px 0 10px -2px ${accent}88`;
+  if (glowOp > 0) return isDark ? `inset 3px 0 8px -3px rgba(255,255,255,${glowOp * 0.35})` : `inset 3px 0 8px -3px rgba(0,0,0,${glowOp * 0.35})`;
   return 'none';
 }
 
@@ -719,12 +711,6 @@ function getTocItemStyle(item: TocItem, dist: number, activeId: string, isDark: 
   else if (isActive) { opacity = 1;    glowOp = 1; }
   else { opacity = Math.max(0.32, 0.82 - dist * 0.18); glowOp = Math.max(0, 0.5 - dist * 0.16); }
   const baseFontSize = mobile ? 1.05 : 0.92;
-  const activeGlowBg = isDark
-    ? `radial-gradient(circle at 8% 50%, ${t.accent}33 0%, ${t.accent}16 38%, rgba(255,255,255,0.035) 100%)`
-    : `radial-gradient(circle at 8% 50%, ${t.accent}1f 0%, ${t.accent}0f 42%, rgba(0,0,0,0.02) 100%)`;
-  const nearGlowBg = glowOp > 0
-    ? (isDark ? `rgba(255,255,255,${glowOp * 0.035})` : `rgba(0,0,0,${glowOp * 0.018})`)
-    : 'transparent';
   const fontSizeStep = mobile ? 0.05 : 0.04;
   const fontSize     = `${baseFontSize - (item.level - 2) * fontSizeStep}rem`;
   const paddingLeft  = mobile ? 14 + (item.level - 2) * 18 : 12 + (item.level - 2) * 14;
@@ -732,13 +718,17 @@ function getTocItemStyle(item: TocItem, dist: number, activeId: string, isDark: 
     isActive,
     borderClr: tocBorderColor(isActive, glowOp, isDark, t.accent),
     shadow:    tocShadow(isActive, glowOp, isDark, t.accent),
-    background: isActive ? activeGlowBg : nearGlowBg,
     fontSize, paddingLeft,
     color: tocColor(isActive, opacity, isDark, t.accent),
   };
 }
 
 // ─── TocPanelContent ──────────────────────────────────────────────────────────
+
+function getTocItemBackground(isActive: boolean, isDark: boolean): string {
+  if (!isActive) return 'transparent';
+  return isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.03)';
+}
 
 function getTocItemFontWeight(isActive: boolean, level: number): number {
   if (isActive) return 600;
@@ -760,6 +750,7 @@ const TocPanelContent: React.FC<{
       {toc.map((item, index) => {
         const dist  = Math.abs(index - activeIndex);
         const style = getTocItemStyle(item, dist, activeId, isDark, mobile);
+        const bg    = getTocItemBackground(style.isActive, isDark);
         const fw    = getTocItemFontWeight(style.isActive, item.level);
         return (
           <button key={item.id}
@@ -771,13 +762,12 @@ const TocPanelContent: React.FC<{
               paddingRight:  mobile ? '1rem'    : '0.75rem',
               paddingLeft:   `${style.paddingLeft}px`,
               fontSize: style.fontSize, lineHeight: 1.45,
-              position: 'relative',
-              background: style.background, border: '1px solid transparent', cursor: 'pointer',
+              background: bg, border: 'none', cursor: 'pointer',
               borderLeft: '2px solid', borderLeftColor: style.borderClr,
-              boxShadow: style.shadow, borderRadius: '10px',
+              boxShadow: style.shadow, borderRadius: '0 8px 8px 0',
               color: style.color, fontWeight: fw,
-              textShadow: style.isActive ? `0 0 10px ${t.accent}99, 0 0 24px ${t.accent}55` : 'none',
-              transition: 'background 0.18s, box-shadow 0.18s, color 0.18s, transform 0.18s',
+              textShadow: style.isActive ? `0 0 8px ${t.accent}cc, 0 0 18px ${t.accent}88, 0 0 30px ${t.accent}44` : 'none',
+              transition: 'text-shadow 0.18s, color 0.18s',
             }}
           >{item.text}</button>
         );
@@ -997,10 +987,10 @@ function deriveDesktopNavValues(
 // ─── Подкомпоненты DesktopNav ─────────────────────────────────────────────────
 
 const DesktopSidebarShell: React.FC<{
-  isDocsPage: boolean; chromeGap: number; chromeTopGap: number;
+  enabled: boolean; isDocsPage: boolean; chromeGap: number; chromeTopGap: number;
   chromeRadius: number; sidebarShellWidth: number; sidebarBg: string;
-}> = ({ isDocsPage, chromeGap, chromeTopGap, chromeRadius, sidebarShellWidth, sidebarBg }) => {
-  if (!isDocsPage) return null;
+}> = ({ enabled, isDocsPage, chromeGap, chromeTopGap, chromeRadius, sidebarShellWidth, sidebarBg }) => {
+  if (!enabled || !isDocsPage) return null;
   return (
     <div
       aria-hidden
@@ -1048,7 +1038,7 @@ const DesktopReadingModeMenu: React.FC<{
 const DesktopRail: React.FC<{
   isDark: boolean; toggleTheme: () => void; logoPath: string;
   isDocsPage: boolean; chromeGap: number; chromeTopGap: number; chromeRadius: number;
-  panelOpen: boolean; t: ReturnType<typeof tk>;
+  panelOpen: boolean; shellEnabled: boolean; t: ReturnType<typeof tk>;
   state: DesktopNavState; derived: DesktopNavDerived;
   readingModeEnabled: boolean;
   onHideRail: () => void;
@@ -1056,7 +1046,7 @@ const DesktopRail: React.FC<{
   onTogglePanel: (panel: Exclude<PanelType, null>) => void;
 }> = ({
   isDark, toggleTheme, logoPath,
-  isDocsPage, chromeGap, chromeTopGap, chromeRadius, panelOpen, t,
+  isDocsPage, chromeGap, chromeTopGap, chromeRadius, panelOpen, shellEnabled, t,
   state, derived, readingModeEnabled,
   onHideRail, onOpenSearch, onTogglePanel,
 }) => {
@@ -1068,14 +1058,14 @@ const DesktopRail: React.FC<{
       position: 'fixed', left: chromeGap, top: chromeTopGap,
       height: isDocsPage ? `calc(100vh - ${chromeTopGap + chromeGap}px)` : '100vh',
       width: RAIL_W,
-      background: isDocsPage ? 'transparent' : sidebarBg,
-      border: isDocsPage ? 'none' : `1px solid ${t.border}`,
+      background: isDocsPage && shellEnabled ? 'transparent' : sidebarBg,
+      border: isDocsPage && shellEnabled ? 'none' : `1px solid ${t.border}`,
       borderRight: 'none',
       borderRadius: panelOpen ? `${chromeRadius}px 0 0 ${chromeRadius}px` : chromeRadius,
       display: 'flex', flexDirection: 'column', alignItems: 'center',
       zIndex: 50, padding: '8px 0', gap: '2px',
-      backdropFilter: isDocsPage ? 'none' : 'blur(12px)',
-      WebkitBackdropFilter: isDocsPage ? 'none' : 'blur(12px)',
+      backdropFilter: isDocsPage && shellEnabled ? 'none' : 'blur(12px)',
+      WebkitBackdropFilter: isDocsPage && shellEnabled ? 'none' : 'blur(12px)',
     }}>
       <div style={{ width: RAIL_W, height: 48, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
         <BrandLogo logoPath={logoPath} size={28} />
@@ -1111,9 +1101,6 @@ const DesktopRail: React.FC<{
             <RailBtn icon={<ArrowUp size={18} />} label="Наверх"     isDark={isDark} onClick={() => globalThis.scrollTo({ top: 0, behavior: 'smooth' })}            title="Наверх" />
           </>
         )}
-        {isStandardMode && !standardTocVisible && (
-          <RailBtn icon={<List size={18} />} label="TOC" isDark={isDark} onClick={() => state.setStandardTocVisible(true)} title="Показать оглавление" />
-        )}
         <RailBtn icon={<Mail size={18} />} label="Контакты" isDark={isDark} isActive={activePanel === 'contacts'} onClick={() => onTogglePanel('contacts')} title="Контакты" />
       </div>
     </aside>
@@ -1123,6 +1110,7 @@ const DesktopRail: React.FC<{
 const DesktopSlidingPanel: React.FC<{
   isDocsPage: boolean; chromeGap: number; chromeTopGap: number; chromeRadius: number;
   panelOpen: boolean; panelWidth: number; panelBg: string; t: ReturnType<typeof tk>;
+  shellEnabled: boolean;
   panelTitle: Exclude<PanelType, null>; isStandardMode: boolean;
   currentDocSlug?: string; toc: TocItem[]; activeId: string; isDark: boolean;
   onResizeMouseDown: (e: React.MouseEvent) => void;
@@ -1130,7 +1118,7 @@ const DesktopSlidingPanel: React.FC<{
 }> = ({
   isDocsPage, chromeGap, chromeTopGap, chromeRadius,
   panelOpen, panelWidth, panelBg, t,
-  panelTitle, isStandardMode,
+  shellEnabled, panelTitle, isStandardMode,
   currentDocSlug, toc, activeId, isDark,
   onResizeMouseDown, onClose,
 }) => {
@@ -1144,7 +1132,7 @@ const DesktopSlidingPanel: React.FC<{
       position: 'fixed', left: chromeGap + RAIL_W, top: chromeTopGap,
       height: isDocsPage ? `calc(100vh - ${chromeTopGap + chromeGap}px)` : '100vh',
       width: panelOpen ? panelWidth : 0,
-      background: isDocsPage ? 'transparent' : panelBg,
+      background: isDocsPage && shellEnabled ? 'transparent' : panelBg,
       border: panelBorder,
       borderLeft: 'none',
       borderRadius: panelOpen ? `0 ${chromeRadius}px ${chromeRadius}px 0` : 0,
@@ -1227,6 +1215,8 @@ const DesktopNav: React.FC<{
   const readingModeEnabled = showDocActions;
   const derived = deriveDesktopNavValues(state, currentDocSlug, readingModeEnabled, isDark, floatingChrome);
   const { isDocsPage, chromeGap, chromeTopGap, chromeRadius, sidebarBg, isStandardMode, panelOpen, sidebarShellWidth, panelTitle } = derived;
+  const contentIsDocsPage = Boolean(currentDocSlug);
+  const shellEnabled = contentIsDocsPage;
   const panelBg = sidebarBg;
 
   useEffect(() => {
@@ -1238,9 +1228,14 @@ const DesktopNav: React.FC<{
   }, [state.standardTocVisible]);
 
   useEffect(() => {
-    buildCssVars(state.railVisible, isDocsPage, panelOpen, state.panelWidth, isStandardMode, state.standardTocVisible);
+    if (!contentIsDocsPage) {
+      clearDocCssVars();
+      document.documentElement.style.setProperty('--nav-left', '0px');
+      return () => { document.documentElement.style.removeProperty('--nav-left'); };
+    }
+    buildCssVars(state.railVisible, contentIsDocsPage, panelOpen, state.panelWidth, isStandardMode, state.standardTocVisible);
     return () => { document.documentElement.style.removeProperty('--nav-left'); };
-  }, [state.railVisible, panelOpen, state.panelWidth, isStandardMode, state.standardTocVisible, isDocsPage]);
+  }, [state.railVisible, panelOpen, state.panelWidth, isStandardMode, state.standardTocVisible, contentIsDocsPage]);
 
   useEffect(() => {
     return clearDocCssVars;
@@ -1263,7 +1258,7 @@ const DesktopNav: React.FC<{
   return (
     <>
       <DesktopSidebarShell
-        isDocsPage={isDocsPage} chromeGap={chromeGap} chromeTopGap={chromeTopGap}
+        enabled={shellEnabled} isDocsPage={isDocsPage} chromeGap={chromeGap} chromeTopGap={chromeTopGap}
         chromeRadius={chromeRadius} sidebarShellWidth={sidebarShellWidth} sidebarBg={sidebarBg}
       />
 
@@ -1271,7 +1266,7 @@ const DesktopNav: React.FC<{
         <DesktopRail
           isDark={isDark} toggleTheme={toggleTheme} logoPath={logoPath}
           isDocsPage={isDocsPage} chromeGap={chromeGap} chromeTopGap={chromeTopGap}
-          chromeRadius={chromeRadius} panelOpen={panelOpen} t={t}
+          chromeRadius={chromeRadius} panelOpen={panelOpen} shellEnabled={shellEnabled} t={t}
           state={state} derived={derived}
           readingModeEnabled={readingModeEnabled}
           onHideRail={() => state.setRailVisible(false)}
@@ -1299,7 +1294,7 @@ const DesktopNav: React.FC<{
         <DesktopSlidingPanel
           isDocsPage={isDocsPage} chromeGap={chromeGap} chromeTopGap={chromeTopGap}
           chromeRadius={chromeRadius} panelOpen={panelOpen} panelWidth={state.panelWidth}
-          panelBg={panelBg} t={t} panelTitle={panelTitle} isStandardMode={isStandardMode}
+          panelBg={panelBg} t={t} shellEnabled={shellEnabled} panelTitle={panelTitle} isStandardMode={isStandardMode}
           currentDocSlug={currentDocSlug} toc={toc} activeId={activeId} isDark={isDark}
           onResizeMouseDown={onResizeMouseDown}
           onClose={handlePanelClose}
@@ -1313,6 +1308,19 @@ const DesktopNav: React.FC<{
           toc={toc} activeId={activeId} isDark={isDark}
           onHideToc={() => state.setStandardTocVisible(false)}
         />
+      )}
+
+      {isStandardMode && !state.standardTocVisible && (
+        <button
+          onClick={() => state.setStandardTocVisible(true)}
+          style={{
+            position: 'fixed', right: chromeGap + 12, top: chromeTopGap + 12, zIndex: 56,
+            border: `1px solid ${t.border}`, borderRadius: '8px',
+            background: t.panelBg, color: t.fgMuted, padding: '6px 8px', cursor: 'pointer', fontSize: '0.75rem',
+          }}
+        >
+          Показать TOC
+        </button>
       )}
 
       <AnimatePresence>

--- a/src/features/navigation/components/Navigation.tsx
+++ b/src/features/navigation/components/Navigation.tsx
@@ -54,6 +54,7 @@ interface NavigationProps {
   currentDocSlug?: string;
   toc?: TocItem[];
   activeHeadingId?: string;
+  floatingChrome?: boolean;
 }
 
 interface SiteLogoConfig {
@@ -685,14 +686,22 @@ const NavPanelContent: React.FC<{
 // ─── Вспомогательные функции для ToC ─────────────────────────────────────────
 
 function tocBorderColor(isActive: boolean, glowOp: number, isDark: boolean, accent: string): string {
-  if (isActive)   return accent;
-  if (glowOp > 0) return isDark ? `rgba(255,255,255,${glowOp})` : `rgba(0,0,0,${glowOp})`;
+  if (isActive)   return isDark ? `color-mix(in srgb, ${accent} 72%, white 28%)` : accent;
+  if (glowOp > 0) return isDark ? `rgba(255,255,255,${glowOp * 0.55})` : `rgba(0,0,0,${glowOp * 0.28})`;
   return 'transparent';
 }
 
 function tocShadow(isActive: boolean, glowOp: number, isDark: boolean, accent: string): string {
-  if (isActive)   return `inset 3px 0 10px -2px ${accent}88`;
-  if (glowOp > 0) return isDark ? `inset 3px 0 8px -3px rgba(255,255,255,${glowOp * 0.35})` : `inset 3px 0 8px -3px rgba(0,0,0,${glowOp * 0.35})`;
+  if (isActive) {
+    return isDark
+      ? `inset 0 0 0 1px ${accent}55, 0 0 18px ${accent}55, 0 0 36px ${accent}2f`
+      : `inset 0 0 0 1px ${accent}33, 0 0 18px ${accent}22`;
+  }
+  if (glowOp > 0) {
+    return isDark
+      ? `inset 0 0 0 1px rgba(255,255,255,${glowOp * 0.16}), 0 0 14px rgba(255,255,255,${glowOp * 0.08})`
+      : `inset 0 0 0 1px rgba(0,0,0,${glowOp * 0.08})`;
+  }
   return 'none';
 }
 
@@ -710,6 +719,12 @@ function getTocItemStyle(item: TocItem, dist: number, activeId: string, isDark: 
   else if (isActive) { opacity = 1;    glowOp = 1; }
   else { opacity = Math.max(0.32, 0.82 - dist * 0.18); glowOp = Math.max(0, 0.5 - dist * 0.16); }
   const baseFontSize = mobile ? 1.05 : 0.92;
+  const activeGlowBg = isDark
+    ? `radial-gradient(circle at 8% 50%, ${t.accent}33 0%, ${t.accent}16 38%, rgba(255,255,255,0.035) 100%)`
+    : `radial-gradient(circle at 8% 50%, ${t.accent}1f 0%, ${t.accent}0f 42%, rgba(0,0,0,0.02) 100%)`;
+  const nearGlowBg = glowOp > 0
+    ? (isDark ? `rgba(255,255,255,${glowOp * 0.035})` : `rgba(0,0,0,${glowOp * 0.018})`)
+    : 'transparent';
   const fontSizeStep = mobile ? 0.05 : 0.04;
   const fontSize     = `${baseFontSize - (item.level - 2) * fontSizeStep}rem`;
   const paddingLeft  = mobile ? 14 + (item.level - 2) * 18 : 12 + (item.level - 2) * 14;
@@ -717,17 +732,13 @@ function getTocItemStyle(item: TocItem, dist: number, activeId: string, isDark: 
     isActive,
     borderClr: tocBorderColor(isActive, glowOp, isDark, t.accent),
     shadow:    tocShadow(isActive, glowOp, isDark, t.accent),
+    background: isActive ? activeGlowBg : nearGlowBg,
     fontSize, paddingLeft,
     color: tocColor(isActive, opacity, isDark, t.accent),
   };
 }
 
 // ─── TocPanelContent ──────────────────────────────────────────────────────────
-
-function getTocItemBackground(isActive: boolean, isDark: boolean): string {
-  if (!isActive) return 'transparent';
-  return isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.03)';
-}
 
 function getTocItemFontWeight(isActive: boolean, level: number): number {
   if (isActive) return 600;
@@ -749,7 +760,6 @@ const TocPanelContent: React.FC<{
       {toc.map((item, index) => {
         const dist  = Math.abs(index - activeIndex);
         const style = getTocItemStyle(item, dist, activeId, isDark, mobile);
-        const bg    = getTocItemBackground(style.isActive, isDark);
         const fw    = getTocItemFontWeight(style.isActive, item.level);
         return (
           <button key={item.id}
@@ -761,11 +771,13 @@ const TocPanelContent: React.FC<{
               paddingRight:  mobile ? '1rem'    : '0.75rem',
               paddingLeft:   `${style.paddingLeft}px`,
               fontSize: style.fontSize, lineHeight: 1.45,
-              background: bg, border: 'none', cursor: 'pointer',
+              position: 'relative',
+              background: style.background, border: '1px solid transparent', cursor: 'pointer',
               borderLeft: '2px solid', borderLeftColor: style.borderClr,
-              boxShadow: style.shadow, borderRadius: '0 8px 8px 0',
+              boxShadow: style.shadow, borderRadius: '10px',
               color: style.color, fontWeight: fw,
-              textShadow: style.isActive ? `0 0 12px ${t.accent}55` : 'none',
+              textShadow: style.isActive ? `0 0 10px ${t.accent}99, 0 0 24px ${t.accent}55` : 'none',
+              transition: 'background 0.18s, box-shadow 0.18s, color 0.18s, transform 0.18s',
             }}
           >{item.text}</button>
         );
@@ -966,8 +978,9 @@ function deriveDesktopNavValues(
   currentDocSlug: string | undefined,
   readingModeEnabled: boolean,
   isDark: boolean,
+  floatingChrome = false,
 ): DesktopNavDerived {
-  const isDocsPage       = Boolean(currentDocSlug);
+  const isDocsPage       = Boolean(currentDocSlug) || floatingChrome;
   const chromeGap        = isDocsPage ? DOC_CHROME_GAP : 0;
   const chromeTopGap     = isDocsPage ? DOC_CHROME_TOP_GAP : 0;
   const chromeRadius     = isDocsPage ? DOC_CHROME_RADIUS : 0;
@@ -1205,13 +1218,14 @@ const DesktopTocPanel: React.FC<{
 
 const DesktopNav: React.FC<{
   isDark: boolean; toggleTheme: () => void; currentDocSlug?: string; toc: TocItem[]; activeId: string; showDocActions: boolean; logoPath: string;
-}> = ({ isDark, toggleTheme, currentDocSlug, toc, activeId, showDocActions, logoPath }) => {
+  floatingChrome?: boolean;
+}> = ({ isDark, toggleTheme, currentDocSlug, toc, activeId, showDocActions, logoPath, floatingChrome = false }) => {
   const t   = tk(isDark);
   const state = useDesktopNavState();
   const { onResizeMouseDown } = usePanelResize(state.panelWidth, state.setPanelWidth);
 
   const readingModeEnabled = showDocActions;
-  const derived = deriveDesktopNavValues(state, currentDocSlug, readingModeEnabled, isDark);
+  const derived = deriveDesktopNavValues(state, currentDocSlug, readingModeEnabled, isDark, floatingChrome);
   const { isDocsPage, chromeGap, chromeTopGap, chromeRadius, sidebarBg, isStandardMode, panelOpen, sidebarShellWidth, panelTitle } = derived;
   const panelBg = sidebarBg;
 
@@ -1435,7 +1449,7 @@ const MobileNav: React.FC<{
 
 // ─── Navigation (основной экспорт) ───────────────────────────────────────────
 
-const Navigation: React.FC<NavigationProps> = ({ currentDocSlug, toc = [], activeHeadingId = '' }) => {
+const Navigation: React.FC<NavigationProps> = ({ currentDocSlug, toc = [], activeHeadingId = '', floatingChrome = false }) => {
   const { isDark, toggleTheme } = useTheme();
   const isDesktop = useIsDesktopNav();
   const showDocActions = toc.length > 0 || !!currentDocSlug;
@@ -1469,7 +1483,7 @@ const Navigation: React.FC<NavigationProps> = ({ currentDocSlug, toc = [], activ
 
   const logoPath = getThemeLogoPath(logoConfig, isDark);
 
-  if (isDesktop) return <DesktopNav isDark={isDark} toggleTheme={toggleTheme} currentDocSlug={currentDocSlug} toc={toc} activeId={activeHeadingId} showDocActions={showDocActions} logoPath={logoPath} />;
+  if (isDesktop) return <DesktopNav isDark={isDark} toggleTheme={toggleTheme} currentDocSlug={currentDocSlug} toc={toc} activeId={activeHeadingId} showDocActions={showDocActions} logoPath={logoPath} floatingChrome={floatingChrome} />;
   return <MobileNav isDark={isDark} toggleTheme={toggleTheme} currentDocSlug={currentDocSlug} toc={toc} activeId={activeHeadingId} showDocActions={showDocActions} logoPath={logoPath} />;
 };
 

--- a/src/features/navigation/components/Navigation.tsx
+++ b/src/features/navigation/components/Navigation.tsx
@@ -1016,8 +1016,8 @@ const DesktopReadingModeMenu: React.FC<{
     <div style={{
       position: 'absolute', left: 'calc(100% - 1px)', top: 0, marginLeft: 0, width: '190px', padding: '8px',
       borderRadius: `0 ${radius}px ${radius}px 0`,
-      border: `1px solid ${t.border}`, borderLeft: 'none',
-      background: sidebarBg, boxShadow: '0 16px 50px rgba(0,0,0,0.14)', zIndex: 70,
+      border: 'none',
+      background: sidebarBg, boxShadow: 'none', zIndex: 70,
       backdropFilter: 'blur(14px)', WebkitBackdropFilter: 'blur(14px)',
     }}>
       <button
@@ -1060,8 +1060,7 @@ const DesktopRail: React.FC<{
       height: isDocsPage ? `calc(100vh - ${chromeTopGap + chromeGap}px)` : '100vh',
       width: RAIL_W,
       background: isDocsPage && shellEnabled ? 'transparent' : sidebarBg,
-      border: isDocsPage && shellEnabled ? 'none' : `1px solid ${t.border}`,
-      borderRight: 'none',
+      border: 'none',
       borderRadius: panelOpen ? `${chromeRadius}px 0 0 ${chromeRadius}px` : chromeRadius,
       display: 'flex', flexDirection: 'column', alignItems: 'center',
       zIndex: 50, padding: '8px 0', gap: '2px',
@@ -1123,24 +1122,17 @@ const DesktopSlidingPanel: React.FC<{
   currentDocSlug, toc, activeId, isDark,
   onResizeMouseDown, onClose,
 }) => {
-  const panelBorder = (() => {
-    if (isDocsPage && shellEnabled) return 'none';
-    return panelOpen ? `1px solid ${t.border}` : 'none';
-  })();
-
   return (
     <aside style={{
       position: 'fixed', left: chromeGap + RAIL_W, top: chromeTopGap,
       height: isDocsPage ? `calc(100vh - ${chromeTopGap + chromeGap}px)` : '100vh',
       width: panelOpen ? panelWidth : 0,
       background: isDocsPage && shellEnabled ? 'transparent' : panelBg,
-      border: panelBorder,
-      borderLeft: 'none',
+      border: 'none',
       borderRadius: panelOpen ? `0 ${chromeRadius}px ${chromeRadius}px 0` : 0,
       display: 'flex', flexDirection: 'column', zIndex: 49, overflow: 'hidden',
       pointerEvents: panelOpen ? 'auto' : 'none',
       visibility: panelOpen ? 'visible' : 'hidden',
-      boxShadow: panelOpen && !shellEnabled ? '0 18px 60px rgba(0,0,0,0.14)' : 'none',
       backdropFilter: isDocsPage && shellEnabled ? 'none' : 'blur(14px)',
       WebkitBackdropFilter: isDocsPage && shellEnabled ? 'none' : 'blur(14px)',
     }}>
@@ -1172,10 +1164,9 @@ const DesktopTocPanel: React.FC<{
   <aside style={{
     position: 'fixed', right: chromeGap, top: chromeTopGap, width: TOC_PANEL_W,
     height: isDocsPage ? `calc(100vh - ${chromeTopGap + chromeGap}px)` : '100vh',
-    border: `1px solid ${t.border}`, borderRight: 'none',
+    border: 'none', borderLeft: 'none',
     borderRadius: `${chromeRadius}px 0 0 ${chromeRadius}px`,
     overflow: 'hidden', background: panelBg, zIndex: 48,
-    boxShadow: '0 18px 60px rgba(0,0,0,0.14)',
     display: 'flex', flexDirection: 'column',
     backdropFilter: 'blur(14px)', WebkitBackdropFilter: 'blur(14px)',
   }}>

--- a/src/features/navigation/components/Navigation.tsx
+++ b/src/features/navigation/components/Navigation.tsx
@@ -1017,7 +1017,8 @@ const DesktopReadingModeMenu: React.FC<{
       position: 'absolute', left: 'calc(100% - 1px)', top: 0, marginLeft: 0, width: '190px', padding: '8px',
       borderRadius: `0 ${radius}px ${radius}px 0`,
       border: `1px solid ${t.border}`, borderLeft: 'none',
-      background: sidebarBg, boxShadow: 'none', zIndex: 70,
+      background: sidebarBg, boxShadow: '0 16px 50px rgba(0,0,0,0.14)', zIndex: 70,
+      backdropFilter: 'blur(14px)', WebkitBackdropFilter: 'blur(14px)',
     }}>
       <button
         onClick={() => onSelect('standard')}
@@ -1123,7 +1124,7 @@ const DesktopSlidingPanel: React.FC<{
   onResizeMouseDown, onClose,
 }) => {
   const panelBorder = (() => {
-    if (isDocsPage) return 'none';
+    if (isDocsPage && shellEnabled) return 'none';
     return panelOpen ? `1px solid ${t.border}` : 'none';
   })();
 
@@ -1139,8 +1140,9 @@ const DesktopSlidingPanel: React.FC<{
       display: 'flex', flexDirection: 'column', zIndex: 49, overflow: 'hidden',
       pointerEvents: panelOpen ? 'auto' : 'none',
       visibility: panelOpen ? 'visible' : 'hidden',
-      backdropFilter: isDocsPage ? 'none' : 'blur(14px)',
-      WebkitBackdropFilter: isDocsPage ? 'none' : 'blur(14px)',
+      boxShadow: panelOpen && !shellEnabled ? '0 18px 60px rgba(0,0,0,0.14)' : 'none',
+      backdropFilter: isDocsPage && shellEnabled ? 'none' : 'blur(14px)',
+      WebkitBackdropFilter: isDocsPage && shellEnabled ? 'none' : 'blur(14px)',
     }}>
       {panelOpen && (
         <>
@@ -1170,9 +1172,10 @@ const DesktopTocPanel: React.FC<{
   <aside style={{
     position: 'fixed', right: chromeGap, top: chromeTopGap, width: TOC_PANEL_W,
     height: isDocsPage ? `calc(100vh - ${chromeTopGap + chromeGap}px)` : '100vh',
-    border: 'none', borderLeft: 'none',
+    border: `1px solid ${t.border}`, borderRight: 'none',
     borderRadius: `${chromeRadius}px 0 0 ${chromeRadius}px`,
     overflow: 'hidden', background: panelBg, zIndex: 48,
+    boxShadow: '0 18px 60px rgba(0,0,0,0.14)',
     display: 'flex', flexDirection: 'column',
     backdropFilter: 'blur(14px)', WebkitBackdropFilter: 'blur(14px)',
   }}>

--- a/src/features/ui-components/NewUIComponentViewer.tsx
+++ b/src/features/ui-components/NewUIComponentViewer.tsx
@@ -926,7 +926,7 @@ const PreviewPanel: React.FC<ComponentRenderProps & {
   return (
     <div style={{ position: 'relative', width: '100%', overflow: 'visible' }}>
       <div style={{
-        position: 'absolute', top: 10, right: 10, zIndex: 5,
+        position: 'absolute', top: 10, right: 10, zIndex: 1,
         display: 'flex', gap: 6,
       }}>
         <button

--- a/src/shared/components/CodeBlock.tsx
+++ b/src/shared/components/CodeBlock.tsx
@@ -506,9 +506,44 @@ function SingleCodeContent({ code, language, isModal, searchQuery, setSearchQuer
         </>
       )}
 
-      {isMobile && (
+      {isMobile && (isModal ? (
+        <>
+          <button
+            onClick={handleCopy}
+            title={isCopied ? 'Скопировано!' : 'Копировать'}
+            style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              width: 36, height: 36, borderRadius: 8,
+              border: `1px solid ${isCopied ? 'rgba(34,197,94,0.4)' : t.btnBdr}`,
+              background: isCopied ? 'rgba(34,197,94,0.16)' : t.btnBg,
+              color: isCopied ? '#22c55e' : t.btnClr,
+              cursor: 'pointer', flexShrink: 0, transition: 'all 0.13s',
+            }}
+            onMouseEnter={e => { if (!isCopied) (e.currentTarget as HTMLButtonElement).style.background = t.btnHov; }}
+            onMouseLeave={e => { if (!isCopied) (e.currentTarget as HTMLButtonElement).style.background = t.btnBg; }}
+          >
+            {isCopied ? <Check size={16} strokeWidth={2.5} /> : <Copy size={16} />}
+          </button>
+          <button
+            onClick={() => setIsFullscreen(false)}
+            title="Закрыть"
+            style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              width: 36, height: 36, borderRadius: 8,
+              border: `1px solid ${t.btnBdr}`,
+              background: t.btnBg,
+              color: t.btnClr,
+              cursor: 'pointer', flexShrink: 0, transition: 'all 0.13s',
+            }}
+            onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = t.btnHov; }}
+            onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = t.btnBg; }}
+          >
+            <X size={16} />
+          </button>
+        </>
+      ) : (
         <MobileMenu isDark={isDark} code={code} onFullscreen={() => setIsFullscreen(true)} />
-      )}
+      ))}
     </div>
   );
 

--- a/src/shared/components/CodeBlock.tsx
+++ b/src/shared/components/CodeBlock.tsx
@@ -6,6 +6,7 @@ import {
 } from 'lucide-react';
 import { TableContext } from '../lib/htmlParser';
 import Overlay from './Overlay';
+import { getTableUiTokens } from '@/features/table/components/tableUiTheme';
 import { useDragScroll } from '@/features/table/hooks/useDragScroll';
 import hljs from 'highlight.js/lib/core';
 import { makeTokens, themed } from '@/shared/tokens/theme';
@@ -35,10 +36,6 @@ function tk(isDark: boolean) {
     btnBdr: themed(isDark, 'rgba(255,255,255,0.12)', 'rgba(0,0,0,0.12)'),
     btnHov: themed(isDark, 'rgba(255,255,255,0.14)', 'rgba(0,0,0,0.12)'),
     btnClr: themed(isDark, 'rgba(255,255,255,0.72)', 'rgba(0,0,0,0.68)'),
-    menuBg: themed(isDark, '#222222', '#eceae6'),
-    menuBdr: themed(isDark, 'rgba(255,255,255,0.12)', 'rgba(0,0,0,0.1)'),
-    menuHov: themed(isDark, 'rgba(255,255,255,0.08)', 'rgba(0,0,0,0.06)'),
-    menuClr: themed(isDark, 'rgba(255,255,255,0.85)', 'rgba(0,0,0,0.82)'),
     fg: themed(isDark, '#e8e8e8', '#1a1a1a'),
     fgMuted: themed(isDark, 'rgba(255,255,255,0.35)', 'rgba(0,0,0,0.38)'),
     footerClr: themed(isDark, 'rgba(255,255,255,0.22)', 'rgba(0,0,0,0.32)'),
@@ -290,98 +287,130 @@ function Pill({ onClick, title, label, icon, t, active, success, btnRef }: {
   );
 }
 
-function MobileMenu({ t, code, onFullscreen }: {
-  readonly t: ReturnType<typeof tk>;
+
+const CodePortalMenu: React.FC<{
+  pos: { top: number; left: number };
+  isDark: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+  minWidth?: number;
+}> = ({ pos, isDark, onClose, children, minWidth = 220 }) => {
+  const t = getTableUiTokens(isDark);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const onMouse = (e: MouseEvent) => { if (!ref.current?.contains(e.target as Node)) onClose(); };
+    const onScroll = () => onClose();
+    document.addEventListener('mousedown', onMouse);
+    window.addEventListener('scroll', onScroll, { capture: true, passive: true });
+    return () => {
+      document.removeEventListener('mousedown', onMouse);
+      window.removeEventListener('scroll', onScroll, true);
+    };
+  }, [onClose]);
+
+  return createPortal(
+    <>
+      <style>{`@keyframes tbIn{from{opacity:0;transform:translateY(-5px) scale(0.97)}to{opacity:1;transform:none}}`}</style>
+      <div ref={ref} style={{
+        position: 'fixed', top: pos.top, left: pos.left, minWidth, zIndex: 9999,
+        background: t.menuBg, border: `1px solid ${t.menuBdr}`,
+        borderRadius: 10,
+        boxShadow: isDark ? '0 8px 32px rgba(0,0,0,0.7)' : '0 8px 28px rgba(0,0,0,0.16)',
+        overflow: 'hidden', animation: 'tbIn 0.13s cubic-bezier(0.2,0,0,1)',
+      }}>
+        {children}
+      </div>
+    </>,
+    document.body,
+  );
+};
+
+function MobileMenu({ isDark, code, onFullscreen }: {
+  readonly isDark: boolean;
   readonly code: string;
   readonly onFullscreen: () => void;
 }) {
-  const [open, setOpen]     = useState(false);
-  const [copied, setCopied] = useState(false);
-  const [menuPos, setMenuPos] = useState({ top: 0, left: 0 });
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const menuRef    = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const onMouse = (e: MouseEvent) => {
-      const target = e.target instanceof Node ? e.target : null;
-      if (
-        menuRef.current?.contains(target) ||
-        triggerRef.current?.contains(target)
-      ) return;
-      setOpen(false);
-    };
-    document.addEventListener('mousedown', onMouse, true);
-    return () => document.removeEventListener('mousedown', onMouse, true);
-  }, [open]);
+  const [open, setOpen]       = useState(false);
+  const [copied, setCopied]   = useState(false);
+  const [pos, setPos]         = useState({ top: 0, left: 0 });
+  const ref = useRef<HTMLButtonElement>(null);
+  const t = getTableUiTokens(isDark);
 
   const toggle = () => {
     if (open) { setOpen(false); return; }
-    const r = triggerRef.current?.getBoundingClientRect();
+    const r = ref.current?.getBoundingClientRect();
     if (!r) return;
-    const mw = 200;
-    setMenuPos({ top: r.bottom + 4, left: Math.max(8, Math.min(r.right - mw, window.innerWidth - mw - 8)) });
+    const mw = 220;
+    setPos({ top: r.bottom + 6, left: Math.max(8, Math.min(r.right - mw, window.innerWidth - mw - 8)) });
     setOpen(true);
   };
 
   const doCopy = async () => {
     await navigator.clipboard.writeText(code);
     setCopied(true);
-    setTimeout(() => { setCopied(false); }, 2000);
+    setTimeout(() => { setCopied(false); setOpen(false); }, 1500);
   };
 
-  const menu = open ? (
-    <>
-      <style>{`@keyframes cbMenuIn{from{opacity:0;transform:translateY(-5px) scale(0.97)}to{opacity:1;transform:none}}`}</style>
-      <div ref={menuRef} style={{
-        position: 'fixed', top: menuPos.top, left: menuPos.left,
-        minWidth: 200, zIndex: 99999,
-        background: t.menuBg, border: `1px solid ${t.menuBdr}`,
-        borderRadius: 10,
-        boxShadow: '0 8px 32px rgba(0,0,0,0.7)',
-        overflow: 'hidden',
-        animation: 'cbMenuIn 0.13s cubic-bezier(0.2,0,0,1)',
-      }}>
-        <button onClick={doCopy} style={{
-          width: '100%', padding: '11px 14px',
-          display: 'flex', alignItems: 'center', gap: 10,
-          border: 'none', background: copied ? 'rgba(34,197,94,0.12)' : 'transparent',
-          color: copied ? '#22c55e' : t.menuClr,
-          fontSize: 13, fontWeight: copied ? 600 : 400,
-          cursor: 'pointer', textAlign: 'left',
-        }}>
-          <span style={{ display: 'flex', opacity: copied ? 1 : 0.6 }}>
-            {copied ? <Check size={14} strokeWidth={2.5} /> : <Copy size={14} />}
-          </span>
-          <span>{copied ? 'Скопировано!' : 'Скопировать код'}</span>
-        </button>
-        <div style={{ height: 1, background: t.menuBdr }} />
-        <button onClick={() => { onFullscreen(); setOpen(false); }} style={{
-          width: '100%', padding: '11px 14px',
-          display: 'flex', alignItems: 'center', gap: 10,
-          border: 'none', background: 'transparent',
-          color: t.menuClr, fontSize: 13, cursor: 'pointer', textAlign: 'left',
-        }}>
-          <span style={{ display: 'flex', opacity: 0.6 }}><Maximize2 size={14} /></span>
-          <span>Развернуть</span>
-        </button>
-      </div>
-    </>
-  ) : null;
+  const sep = <div style={{ height: 1, margin: '3px 0', background: t.menuBdr }} />;
+
+  const sLabel = (label: string) => (
+    <div style={{ padding: '7px 14px 3px', fontSize: 10, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.07em', color: t.menuSub }}>{label}</div>
+  );
+
+  const mRow = (onClick: () => void, icon: React.ReactNode, label: string, sub?: string, green?: boolean) => {
+    const rowColor = green ? '#22c55e' : t.menuClr;
+    const rowBg = green ? t.greenBg : 'transparent';
+    const rowBgHover = green ? t.greenBg : t.menuHov;
+
+    return (
+      <button onClick={onClick} style={{
+        width: '100%', padding: sub ? '10px 14px' : '11px 14px',
+        display: 'flex', flexDirection: sub ? 'column' : 'row',
+        alignItems: sub ? 'flex-start' : 'center', gap: sub ? 2 : 10,
+        border: 'none', background: rowBg,
+        cursor: 'pointer', textAlign: 'left',
+        color: rowColor,
+        fontSize: 13, fontWeight: green ? 600 : 400, transition: 'background 0.1s',
+      }}
+        onMouseEnter={e => { if (!green) (e.currentTarget as HTMLButtonElement).style.background = rowBgHover; }}
+        onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = rowBg; }}
+      >
+        {!sub && <span style={{ opacity: green ? 1 : 0.6, flexShrink: 0, display: 'flex' }}>{icon}</span>}
+        <span style={{ flex: 1, fontWeight: 500 }}>{label}</span>
+        {sub && <span style={{ fontSize: 11, color: green ? t.greenSub : t.menuSub }}>{sub}</span>}
+      </button>
+    );
+  };
 
   return (
     <>
-      <button ref={triggerRef} onClick={toggle} style={{
+      <button ref={ref} onClick={toggle} style={{
         display: 'flex', alignItems: 'center', justifyContent: 'center',
         width: 36, height: 36, borderRadius: 8,
-        border: `1px solid ${t.btnBdr}`,
-        background: open ? t.btnHov : t.btnBg,
-        color: t.btnClr, cursor: 'pointer', flexShrink: 0,
-      }}>
+        border: `1px solid ${open ? t.btnActBdr : t.btnBdr}`,
+        background: open ? t.btnActBg : t.btnBg,
+        color: open ? t.btnActClr : t.btnClr,
+        cursor: 'pointer', flexShrink: 0, transition: 'all 0.13s',
+      }}
+        onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = t.btnHov; }}
+        onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = open ? t.btnActBg : t.btnBg; }}
+      >
         <MoreHorizontal size={16} />
       </button>
-
-      {menu && createPortal(menu, document.body)}
+      {open && (
+        <CodePortalMenu pos={pos} isDark={isDark} onClose={() => setOpen(false)} minWidth={220}>
+          {sLabel('Копировать')}
+          {mRow(doCopy,
+            copied ? <Check size={14} strokeWidth={2.5} /> : <Copy size={14} />,
+            copied ? 'Скопировано!' : 'Код',
+            copied ? undefined : 'Скопировать содержимое',
+            copied)}
+          {sep}
+          {mRow(() => { onFullscreen(); setOpen(false); }, <Maximize2 size={14} />, 'На весь экран')}
+          <div style={{ height: 4 }} />
+        </CodePortalMenu>
+      )}
     </>
   );
 }
@@ -398,6 +427,7 @@ interface SingleCodeBlockProps {
   readonly isExpanded: boolean;
   readonly setIsExpanded: (v: boolean) => void;
   readonly isMobile: boolean;
+  readonly isDark: boolean;
   readonly t: ReturnType<typeof tk>;
 }
 
@@ -412,7 +442,7 @@ function pluralLines(n: number): string {
   return 'строк';
 }
 
-function SingleCodeContent({ code, language, isModal, searchQuery, setSearchQuery, isCopied, handleCopy, setIsFullscreen, isExpanded, setIsExpanded, isMobile, t }: SingleCodeBlockProps) {
+function SingleCodeContent({ code, language, isModal, searchQuery, setSearchQuery, isCopied, handleCopy, setIsFullscreen, isExpanded, setIsExpanded, isMobile, isDark, t }: SingleCodeBlockProps) {
   const lines = useMemo(() => {
     const raw = code.split('\n');
     if (raw.at(-1) === '') raw.pop();
@@ -477,7 +507,7 @@ function SingleCodeContent({ code, language, isModal, searchQuery, setSearchQuer
       )}
 
       {isMobile && (
-        <MobileMenu t={t} code={code} onFullscreen={() => setIsFullscreen(true)} />
+        <MobileMenu isDark={isDark} code={code} onFullscreen={() => setIsFullscreen(true)} />
       )}
     </div>
   );
@@ -651,6 +681,7 @@ export function CodeBlock({ code, language = '', tabs }: CodeBlockProps) {
     isExpanded,
     setIsExpanded,
     isMobile,
+    isDark,
     t,
   };
 

--- a/src/shared/components/CodeBlock.tsx
+++ b/src/shared/components/CodeBlock.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useContext, useMemo, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import {
   Copy, Check, Maximize2, Minimize2,
   ChevronDown, ChevronUp, Search, X, MoreHorizontal,
@@ -34,6 +35,10 @@ function tk(isDark: boolean) {
     btnBdr: themed(isDark, 'rgba(255,255,255,0.12)', 'rgba(0,0,0,0.12)'),
     btnHov: themed(isDark, 'rgba(255,255,255,0.14)', 'rgba(0,0,0,0.12)'),
     btnClr: themed(isDark, 'rgba(255,255,255,0.72)', 'rgba(0,0,0,0.68)'),
+    menuBg: themed(isDark, '#222222', '#eceae6'),
+    menuBdr: themed(isDark, 'rgba(255,255,255,0.12)', 'rgba(0,0,0,0.1)'),
+    menuHov: themed(isDark, 'rgba(255,255,255,0.08)', 'rgba(0,0,0,0.06)'),
+    menuClr: themed(isDark, 'rgba(255,255,255,0.85)', 'rgba(0,0,0,0.82)'),
     fg: themed(isDark, '#e8e8e8', '#1a1a1a'),
     fgMuted: themed(isDark, 'rgba(255,255,255,0.35)', 'rgba(0,0,0,0.38)'),
     footerClr: themed(isDark, 'rgba(255,255,255,0.22)', 'rgba(0,0,0,0.32)'),
@@ -325,7 +330,44 @@ function MobileMenu({ t, code, onFullscreen }: {
     setTimeout(() => { setCopied(false); }, 2000);
   };
 
-  const menuBg  = t.codeBg === '#0d0d0d' ? '#1a1a1a' : '#eceae6';
+  const menu = open ? (
+    <>
+      <style>{`@keyframes cbMenuIn{from{opacity:0;transform:translateY(-5px) scale(0.97)}to{opacity:1;transform:none}}`}</style>
+      <div ref={menuRef} style={{
+        position: 'fixed', top: menuPos.top, left: menuPos.left,
+        minWidth: 200, zIndex: 99999,
+        background: t.menuBg, border: `1px solid ${t.menuBdr}`,
+        borderRadius: 10,
+        boxShadow: '0 8px 32px rgba(0,0,0,0.7)',
+        overflow: 'hidden',
+        animation: 'cbMenuIn 0.13s cubic-bezier(0.2,0,0,1)',
+      }}>
+        <button onClick={doCopy} style={{
+          width: '100%', padding: '11px 14px',
+          display: 'flex', alignItems: 'center', gap: 10,
+          border: 'none', background: copied ? 'rgba(34,197,94,0.12)' : 'transparent',
+          color: copied ? '#22c55e' : t.menuClr,
+          fontSize: 13, fontWeight: copied ? 600 : 400,
+          cursor: 'pointer', textAlign: 'left',
+        }}>
+          <span style={{ display: 'flex', opacity: copied ? 1 : 0.6 }}>
+            {copied ? <Check size={14} strokeWidth={2.5} /> : <Copy size={14} />}
+          </span>
+          <span>{copied ? 'Скопировано!' : 'Скопировать код'}</span>
+        </button>
+        <div style={{ height: 1, background: t.menuBdr }} />
+        <button onClick={() => { onFullscreen(); setOpen(false); }} style={{
+          width: '100%', padding: '11px 14px',
+          display: 'flex', alignItems: 'center', gap: 10,
+          border: 'none', background: 'transparent',
+          color: t.menuClr, fontSize: 13, cursor: 'pointer', textAlign: 'left',
+        }}>
+          <span style={{ display: 'flex', opacity: 0.6 }}><Maximize2 size={14} /></span>
+          <span>Развернуть</span>
+        </button>
+      </div>
+    </>
+  ) : null;
 
   return (
     <>
@@ -339,39 +381,7 @@ function MobileMenu({ t, code, onFullscreen }: {
         <MoreHorizontal size={16} />
       </button>
 
-      {open && (
-        <div ref={menuRef} style={{
-          position: 'fixed', top: menuPos.top, left: menuPos.left,
-          minWidth: 200, zIndex: 99999,
-          background: menuBg, border: `1px solid ${t.btnBdr}`,
-          borderRadius: 10, boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
-          overflow: 'hidden',
-        }}>
-          <button onClick={doCopy} style={{
-            width: '100%', padding: '11px 14px',
-            display: 'flex', alignItems: 'center', gap: 10,
-            border: 'none', background: copied ? 'rgba(34,197,94,0.12)' : 'transparent',
-            color: copied ? '#22c55e' : t.btnClr,
-            fontSize: 13, fontWeight: copied ? 600 : 400,
-            cursor: 'pointer', textAlign: 'left',
-          }}>
-            <span style={{ display: 'flex', opacity: copied ? 1 : 0.6 }}>
-              {copied ? <Check size={14} strokeWidth={2.5} /> : <Copy size={14} />}
-            </span>
-            <span>{copied ? 'Скопировано!' : 'Скопировать код'}</span>
-          </button>
-          <div style={{ height: 1, background: t.btnBdr }} />
-          <button onClick={() => { onFullscreen(); setOpen(false); }} style={{
-            width: '100%', padding: '11px 14px',
-            display: 'flex', alignItems: 'center', gap: 10,
-            border: 'none', background: 'transparent',
-            color: t.btnClr, fontSize: 13, cursor: 'pointer', textAlign: 'left',
-          }}>
-            <span style={{ display: 'flex', opacity: 0.6 }}><Maximize2 size={14} /></span>
-            <span>Развернуть</span>
-          </button>
-        </div>
-      )}
+      {menu && createPortal(menu, document.body)}
     </>
   );
 }

--- a/src/shared/components/ImageCard.tsx
+++ b/src/shared/components/ImageCard.tsx
@@ -1,6 +1,5 @@
-import React, { useState, useContext } from 'react';
+import React, { useContext } from 'react';
 import { TableContext } from '../lib/htmlParser';
-import Overlay from './Overlay';
 
 interface ImageCardProps {
   src: string;
@@ -10,126 +9,59 @@ interface ImageCardProps {
 }
 
 const ImageCard: React.FC<ImageCardProps> = ({ src, alt, title, isDark = false }) => {
-  const [lightboxOpen, setLightboxOpen] = useState(false);
-
   return (
-    <>
-      <span
+    <span
+      style={{
+        display: 'inline-block',
+        maxWidth: '100%',
+        margin: '1.25rem 0',
+        borderRadius: '10px',
+        border: isDark ? '1px solid rgba(255,255,255,0.1)' : '1px solid rgba(0,0,0,0.1)',
+        background: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.02)',
+        overflow: 'hidden',
+        boxShadow: isDark
+          ? '0 2px 16px rgba(0,0,0,0.5)'
+          : '0 2px 12px rgba(0,0,0,0.08)',
+        verticalAlign: 'top',
+      }}
+    >
+      <img
+        src={src}
+        alt={alt}
+        loading="lazy"
         style={{
-          display: 'inline-block',
+          display: 'block',
           maxWidth: '100%',
-          margin: '1.25rem 0',
-          borderRadius: '10px',
-          border: isDark ? '1px solid rgba(255,255,255,0.1)' : '1px solid rgba(0,0,0,0.1)',
-          background: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.02)',
-          overflow: 'hidden',
-          boxShadow: isDark
-            ? '0 2px 16px rgba(0,0,0,0.5)'
-            : '0 2px 12px rgba(0,0,0,0.08)',
-          verticalAlign: 'top',
+          maxHeight: '480px',
+          width: 'auto',
+          height: 'auto',
+          objectFit: 'contain',
+          margin: 0,
+          border: 'none',
+          borderRadius: title ? '0' : '9px',
         }}
-      >
-        <button
-          type="button"
-          onClick={() => setLightboxOpen(true)}
-          aria-label={`Открыть изображение: ${alt}`}
+      />
+
+      {title && (
+        <span
           style={{
             display: 'block',
-            padding: 0,
-            border: 'none',
-            background: 'transparent',
-            cursor: 'zoom-in',
-            borderRadius: title ? '0' : '9px',
-            overflow: 'hidden',
+            textAlign: 'center',
+            fontSize: '0.78rem',
+            fontStyle: 'italic',
+            padding: '0.5rem 0.75rem',
+            color: isDark ? 'rgba(255,255,255,0.5)' : 'rgba(0,0,0,0.5)',
+            borderTop: isDark
+              ? '1px solid rgba(255,255,255,0.08)'
+              : '1px solid rgba(0,0,0,0.07)',
+            lineHeight: 1.4,
+            background: isDark ? 'rgba(255,255,255,0.02)' : 'rgba(0,0,0,0.02)',
           }}
         >
-          <img
-            src={src}
-            alt={alt}
-            loading="lazy"
-            style={{
-              display: 'block',
-              maxWidth: '100%',
-              maxHeight: '480px',
-              width: 'auto',
-              height: 'auto',
-              objectFit: 'contain',
-              margin: 0,
-              border: 'none',
-              borderRadius: title ? '0' : '9px',
-              transition: 'opacity 0.2s',
-            }}
-            onMouseEnter={(e) => { e.currentTarget.style.opacity = '0.88'; }}
-            onMouseLeave={(e) => { e.currentTarget.style.opacity = '1'; }}
-          />
-        </button>
-
-        {title && (
-          <span
-            style={{
-              display: 'block',
-              textAlign: 'center',
-              fontSize: '0.78rem',
-              fontStyle: 'italic',
-              padding: '0.5rem 0.75rem',
-              color: isDark ? 'rgba(255,255,255,0.5)' : 'rgba(0,0,0,0.5)',
-              borderTop: isDark
-                ? '1px solid rgba(255,255,255,0.08)'
-                : '1px solid rgba(0,0,0,0.07)',
-              lineHeight: 1.4,
-              background: isDark ? 'rgba(255,255,255,0.02)' : 'rgba(0,0,0,0.02)',
-            }}
-          >
-            {title}
-          </span>
-        )}
-      </span>
-
-      {lightboxOpen && (
-        <Overlay onClose={() => setLightboxOpen(false)} backdropCursor="zoom-out">
-          <div style={{ position: 'relative' }}>
-            <img
-              src={src}
-              alt={alt}
-              style={{
-                maxWidth: '90vw',
-                maxHeight: '90vh',
-                objectFit: 'contain',
-                borderRadius: '10px',
-                boxShadow: '0 8px 60px rgba(0,0,0,0.8)',
-                userSelect: 'none',
-                display: 'block',
-              }}
-            />
-            <button
-              type="button"
-              onClick={() => setLightboxOpen(false)}
-              aria-label="Закрыть"
-              style={{
-                position: 'fixed',
-                top: '1.25rem',
-                right: '1.25rem',
-                background: 'rgba(255,255,255,0.12)',
-                border: '1px solid rgba(255,255,255,0.2)',
-                borderRadius: '8px',
-                color: '#fff',
-                width: '36px',
-                height: '36px',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                cursor: 'pointer',
-                fontSize: '18px',
-                lineHeight: 1,
-                zIndex: 1,
-              }}
-            >
-              ✕
-            </button>
-          </div>
-        </Overlay>
+          {title}
+        </span>
       )}
-    </>
+    </span>
   );
 };
 

--- a/src/shared/components/ImageCard.tsx
+++ b/src/shared/components/ImageCard.tsx
@@ -10,19 +10,10 @@ interface ImageCardProps {
 
 const ImageCard: React.FC<ImageCardProps> = ({ src, alt, title, isDark = false }) => {
   return (
-    <span
+    <figure
       style={{
-        display: 'inline-block',
-        maxWidth: '100%',
         margin: '1.25rem 0',
-        borderRadius: '10px',
-        border: isDark ? '1px solid rgba(255,255,255,0.1)' : '1px solid rgba(0,0,0,0.1)',
-        background: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.02)',
-        overflow: 'hidden',
-        boxShadow: isDark
-          ? '0 2px 16px rgba(0,0,0,0.5)'
-          : '0 2px 12px rgba(0,0,0,0.08)',
-        verticalAlign: 'top',
+        maxWidth: '100%',
       }}
     >
       <img
@@ -32,36 +23,31 @@ const ImageCard: React.FC<ImageCardProps> = ({ src, alt, title, isDark = false }
         style={{
           display: 'block',
           maxWidth: '100%',
-          maxHeight: '480px',
-          width: 'auto',
           height: 'auto',
           objectFit: 'contain',
           margin: 0,
           border: 'none',
-          borderRadius: title ? '0' : '9px',
+          borderRadius: 0,
+          background: 'transparent',
+          boxShadow: 'none',
         }}
       />
 
       {title && (
-        <span
+        <figcaption
           style={{
-            display: 'block',
             textAlign: 'center',
             fontSize: '0.78rem',
             fontStyle: 'italic',
-            padding: '0.5rem 0.75rem',
+            marginTop: '0.45rem',
             color: isDark ? 'rgba(255,255,255,0.5)' : 'rgba(0,0,0,0.5)',
-            borderTop: isDark
-              ? '1px solid rgba(255,255,255,0.08)'
-              : '1px solid rgba(0,0,0,0.07)',
             lineHeight: 1.4,
-            background: isDark ? 'rgba(255,255,255,0.02)' : 'rgba(0,0,0,0.02)',
           }}
         >
           {title}
-        </span>
+        </figcaption>
       )}
-    </span>
+    </figure>
   );
 };
 


### PR DESCRIPTION
### Motivation
- Improve mobile UX for code blocks by ensuring action menus render above content and follow theme tokens used elsewhere. 
- Prevent UI elements from overlapping the Ask AI dropdown and viewer settings by correcting stacking order. 
- Simplify image presentation by removing the fullscreen/lightbox modal so images display inline with captions. 
- Make the table-of-contents and general page navigation visuals more prominent and consistent with a glowing, rounded chrome style. 

### Description
- CodeBlock: portaled the mobile action menu to `document.body` and introduced menu theme tokens (`menuBg`, `menuBdr`, `menuHov`, `menuClr`) so the menu is fixed-position, uses table-style dark tokens and has a higher z-index. (`src/shared/components/CodeBlock.tsx`).
- AskAI & UI viewer: increased Ask AI dropdown stacking (`zIndex` raised) and lowered the viewer settings gear layer to avoid the modal being obscured by viewer controls. (`src/features/docs/components/AskAIButton.tsx`, `src/features/ui-components/NewUIComponentViewer.tsx`).
- Images: removed the lightbox/overlay flow and render images inline with optional caption text beneath them (no fullscreen modal). (`src/shared/components/ImageCard.tsx`, `src/shared/lib/htmlParser.tsx` integrations remain). 
- ToC visuals: updated TOC item rendering to add a glowing radial background, enhanced shadow, rounded item chrome, and text glow when active to create a glowing highlight effect. (`src/features/navigation/components/Navigation.tsx`).
- Navigation chrome: added a `floatingChrome` flag so the navigation chrome (gap/top-gap/radius) can be enabled on pages like the general landing page and wired it up on `GeneralPage`. (`src/features/navigation/components/Navigation.tsx`, `src/features/general/components/GeneralPage.tsx`).

### Testing
- Ran `npm run build` which completed successfully and produced the static build (61 pages built). 
- Ran `npm run lint` which failed due to an environment/package export issue unrelated to the changes (`ERR_PACKAGE_PATH_NOT_EXPORTED` for `eslint` on Node v24.15.0). 
- No browser E2E tests were executed in CI; visual/interactive checks should be validated manually in a browser to confirm stacking, portal behavior and TOC glow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d08fef6b4832fa091118ac382f2a9)