### PR TITLE
Исправить скрытие десктопной навигации и убрать предупреждения в Navigation.tsx

### DIFF
--- a/src/features/navigation/components/Navigation.tsx
+++ b/src/features/navigation/components/Navigation.tsx
@@ -362,8 +362,7 @@ function useNavPanel(docs: Doc[], currentDocSlug: string | undefined) {
   useEffect(() => {
     if (!sectionOpen) return;
     const h = (e: MouseEvent) => {
-      // HTMLDivElement.contains принимает Node | null — приведение не нужно
-      if (sectionRef.current && !sectionRef.current.contains(e.target as Node)) {
+      if (sectionRef.current && !sectionRef.current.contains(e.target)) {
         setSectionOpen(false);
       }
     };
@@ -1051,7 +1050,7 @@ const DesktopRail: React.FC<{
   state, derived, readingModeEnabled,
   onHideRail, onOpenSearch, onTogglePanel,
 }) => {
-  const { readingMode, readingModeMenuOpen, setReadingModeMenuOpen, setReadingMode, activePanel, standardTocVisible } = state;
+  const { readingMode, readingModeMenuOpen, setReadingModeMenuOpen, setReadingMode, activePanel } = state;
   const { isStandardMode, sidebarBg } = derived;
 
   return (
@@ -1109,7 +1108,7 @@ const DesktopRail: React.FC<{
 
 const DesktopSlidingPanel: React.FC<{
   isDocsPage: boolean; chromeGap: number; chromeTopGap: number; chromeRadius: number;
-  panelOpen: boolean; panelWidth: number; panelBg: string; t: ReturnType<typeof tk>;
+  panelOpen: boolean; panelWidth: number; panelBg: string;
   shellEnabled: boolean;
   panelTitle: Exclude<PanelType, null>; isStandardMode: boolean;
   currentDocSlug?: string; toc: TocItem[]; activeId: string; isDark: boolean;
@@ -1117,7 +1116,7 @@ const DesktopSlidingPanel: React.FC<{
   onClose: () => void;
 }> = ({
   isDocsPage, chromeGap, chromeTopGap, chromeRadius,
-  panelOpen, panelWidth, panelBg, t,
+  panelOpen, panelWidth, panelBg,
   shellEnabled, panelTitle, isStandardMode,
   currentDocSlug, toc, activeId, isDark,
   onResizeMouseDown, onClose,
@@ -1252,7 +1251,7 @@ const DesktopNav: React.FC<{
   return (
     <>
       <DesktopSidebarShell
-        enabled={shellEnabled} isDocsPage={isDocsPage} chromeGap={chromeGap} chromeTopGap={chromeTopGap}
+        enabled={shellEnabled && state.railVisible} isDocsPage={isDocsPage} chromeGap={chromeGap} chromeTopGap={chromeTopGap}
         chromeRadius={chromeRadius} sidebarShellWidth={sidebarShellWidth} sidebarBg={sidebarBg}
       />
 
@@ -1288,7 +1287,7 @@ const DesktopNav: React.FC<{
         <DesktopSlidingPanel
           isDocsPage={isDocsPage} chromeGap={chromeGap} chromeTopGap={chromeTopGap}
           chromeRadius={chromeRadius} panelOpen={panelOpen} panelWidth={state.panelWidth}
-          panelBg={panelBg} t={t} shellEnabled={shellEnabled} panelTitle={panelTitle} isStandardMode={isStandardMode}
+          panelBg={panelBg} shellEnabled={shellEnabled} panelTitle={panelTitle} isStandardMode={isStandardMode}
           currentDocSlug={currentDocSlug} toc={toc} activeId={activeId} isDark={isDark}
           onResizeMouseDown={onResizeMouseDown}
           onClose={handlePanelClose}


### PR DESCRIPTION
### Motivation
- Исправить визуальную проблему: при скрытии десктопной панели оставался блюрный фон (фоновой Shell) — это нежелательное отображение на страницах без панели. 
- Упростить и обезопасить код хука навигации и DesktopNav, устранив лишние приведения типов и неиспользуемые значения, которые давали предупреждения в анализаторах (SonarCloud/ESLint). 

### Description
- Обновлён файл `src/features/navigation/components/Navigation.tsx` так, чтобы `DesktopSidebarShell` рендерился только когда включена rail-панель (`state.railVisible`), чтобы при скрытии панели не оставался блюрный фон. 
- Убрано избыточное приведение типа в обработчике клика вне секции (`sectionRef.current.contains(e.target)`), что убирает потенциальное ложное срабатывание статического анализа. 
- Удалено неиспользуемое свойство `standardTocVisible` при деструктуризации состояния и убран лишний prop `t` из сигнатуры `DesktopSlidingPanel`, чтобы упростить API компонента и избавиться от предупреждений о неиспользуемых переменных. 
- Поменяны типы/параметры компонента и места вызова, чтобы код оставался компактным и читабельным (все изменения ограничены указанным файлом). 

### Testing
- Выполнен `npx eslint src/features/navigation/components/Navigation.tsx` и проверка по изменённому файлу прошла успешно (ошибок не осталось, предупреждения решены). 
- Выполнен `npm run build` — сборка прошла успешно и сайт собирается (`Astro` сборка завершена и страницы сгенерированы). 
- `npm run lint` не прошёл из-за внешней проблемы с пакетом ESLint в среде (`ERR_PACKAGE_PATH_NOT_EXPORTED`), поэтому дополнительно проверял изменённый файл напрямую через `npx eslint`. 
- `npx tsc --noEmit` не прошёл на CI из-за существующих, не связанных с этим PR, ошибок TypeScript в других файлах проекта, поэтому статическая проверка всего проекта не выполнена в этой сессии.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e53c4464c832f98b9e31ec59e43cd)