### PR TITLE
Improve initial document loading

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -7,7 +7,7 @@
   <!-- Главная страница -->
   <url>
     <loc>https://opensophy.com/</loc>
-    <lastmod>2026-06-02</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/src/app/layouts/Layout.astro
+++ b/src/app/layouts/Layout.astro
@@ -68,6 +68,17 @@ try {
   faviconPath = '/favicon.png';
 }
 
+
+let docsManifestJson = '[]';
+try {
+  const manifestPath = path.join(process.cwd(), 'public/data/docs/manifest.json');
+  if (fs.existsSync(manifestPath)) {
+    docsManifestJson = fs.readFileSync(manifestPath, 'utf-8');
+  }
+} catch {
+  docsManifestJson = '[]';
+}
+
 const faviconType = faviconPath.endsWith('.svg')
   ? 'image/svg+xml'
   : faviconPath.endsWith('.ico')
@@ -189,6 +200,12 @@ const articleJsonLd = type === 'article' ? JSON.stringify({
     <link rel="icon"             href={faviconPath} type={faviconType} />
     <link rel="apple-touch-icon" href={faviconPath} />
 
+
+    <!-- Preload docs manifest for instant navigation without an extra render loader -->
+    <script is:inline define:vars={{ docsManifestJson }}>
+      window.__HUB_DOC_MANIFEST__ = JSON.parse(docsManifestJson);
+    </script>
+
     <!-- Astro SPA transitions -->
     <ClientRouter />
 
@@ -242,7 +259,7 @@ const articleJsonLd = type === 'article' ? JSON.stringify({
       </ThemeProvider>
     </ErrorBoundary>
 
-    <DevPanelLoader client:only="react" />
+    {import.meta.env.DEV && <DevPanelLoader client:only="react" />}
 
     <!-- Re-apply theme after SPA navigation -->
     <script is:inline>

--- a/src/app/pages/[...slug].astro
+++ b/src/app/pages/[...slug].astro
@@ -71,5 +71,5 @@ if (!doc || !slug) return Astro.redirect('/404');
       <article set:html={doc.content ?? ''} />
     </main>
   </noscript>
-  <DocContent client:only="react" doc={doc} />
+  <DocContent client:load doc={doc} />
 </Layout>

--- a/src/app/pages/index.astro
+++ b/src/app/pages/index.astro
@@ -127,7 +127,7 @@ const lang        = useLanding ? 'ru' : (welcomeDoc?.lang || 'ru');
       <GeneralPageWrapper client:only="react" />
     </>
   ) : welcomeDoc ? (
-    <DocContent client:only="react" doc={welcomeDoc} />
+    <DocContent client:load doc={welcomeDoc} />
   ) : (
     <div style="min-height:100vh;display:flex;align-items:center;justify-content:center;">
       <p>Загрузка...</p>

--- a/src/features/docs/hooks/useDocuments.ts
+++ b/src/features/docs/hooks/useDocuments.ts
@@ -1,5 +1,11 @@
 import { useState, useEffect } from 'react';
 
+declare global {
+  interface Window {
+    __HUB_DOC_MANIFEST__?: DocMetadata[];
+  }
+}
+
 export interface DocMetadata {
   id: string;
   title: string;
@@ -27,12 +33,21 @@ export interface UseManifestResult {
   error: string | null;
 }
 
+function getPreloadedManifest(): DocMetadata[] {
+  if (globalThis.window === undefined) return [];
+  return Array.isArray(globalThis.window.__HUB_DOC_MANIFEST__)
+    ? globalThis.window.__HUB_DOC_MANIFEST__
+    : [];
+}
+
 export function useManifest(): UseManifestResult {
-  const [manifest, setManifest] = useState<DocMetadata[]>([]);
-  const [loading, setLoading]   = useState(true);
+  const [manifest, setManifest] = useState<DocMetadata[]>(() => getPreloadedManifest());
+  const [loading, setLoading]   = useState(() => getPreloadedManifest().length === 0);
   const [error, setError]       = useState<string | null>(null);
 
   useEffect(() => {
+    if (manifest.length > 0) return;
+
     fetch('/data/docs/manifest.json')
       .then(res => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -47,7 +62,7 @@ export function useManifest(): UseManifestResult {
         setError(String(err));
         setLoading(false);
       });
-  }, []);
+  }, [manifest.length]);
 
   return { manifest, loading, error };
 }

--- a/src/shared/lib/htmlParser.tsx
+++ b/src/shared/lib/htmlParser.tsx
@@ -610,6 +610,15 @@ const processElement = (
 };
 
 export const parseHtmlToReact = (html: string): React.ReactNode[] => {
+  if (typeof DOMParser === 'undefined') {
+    return [
+      React.createElement('div', {
+        key: 'ssr-html',
+        dangerouslySetInnerHTML: { __html: sanitizeHtml(html) },
+      }),
+    ];
+  }
+
   const rawDoc = new DOMParser().parseFromString(html, 'text/html');
 
   // KaTeX-элементы сохраняются до санитизации, т.к. DOMPurify может изменить их разметку.


### PR DESCRIPTION
### Motivation
- Remove a visible navigation/loading delay on first page load and ensure article content is immediately available to users (especially on slow/mobile connections). 
- Avoid waiting for the full React bundle to hydrate document pages and reduce unnecessary client-side fetches for the docs manifest.

### Description
- Server-preload the docs manifest into the layout and expose it as `window.__HUB_DOC_MANIFEST__` so navigation can initialize without a client `fetch` (`src/app/layouts/Layout.astro`).
- Update `useManifest` to initialize from the preloaded manifest and skip the fetch when preloaded data exists (`src/features/docs/hooks/useDocuments.ts`).
- Render document content islands with `client:load` instead of `client:only` so pages show server-rendered article HTML immediately (`src/app/pages/[...slug].astro`, `src/app/pages/index.astro`).
- Add an SSR-safe fallback in `parseHtmlToReact` to output sanitized HTML when `DOMParser` is unavailable (server-side), preventing blank content before hydration (`src/shared/lib/htmlParser.tsx`).
- Prevent the dev panel island from mounting in production builds by wrapping `DevPanelLoader` with an `import.meta.env.DEV` check (`src/app/layouts/Layout.astro`).

### Testing
- `npm run build` completed successfully and produced the static site build. 
- `npm run preview` + `curl` smoke-check confirmed the article HTML is present, the preloaded manifest is injected (`__HUB_DOC_MANIFEST__`) and the navigation loader text is not shown. 
- `npm run lint` currently fails due to an environment issue where `scripts/eslint-runner.cjs` imports a non-exported ESLint subpath (`./bin/eslint.js`) under Node v24.15.0 (unrelated to these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f9eb40fe8832fb7c1ad8107a9deb2)