### PR TITLE
Preload docs manifest, lazy-load docs content, SSR-safe HTML parsing, and type/import fixes

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -7,7 +7,7 @@
   <!-- Главная страница -->
   <url>
     <loc>https://opensophy.com/</loc>
-    <lastmod>2026-06-02</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/scripts/eslint-runner.cjs
+++ b/scripts/eslint-runner.cjs
@@ -2,9 +2,11 @@
 "use strict";
 
 const Module = require("node:module");
+const path = require("node:path");
 
 if (typeof Module.enableCompileCache === "function") {
   Module.enableCompileCache = () => ({ status: "DISABLED_BY_RUNNER" });
 }
 
-require("eslint/bin/eslint.js");
+const eslintPackageDir = path.dirname(require.resolve("eslint/package.json"));
+require(path.join(eslintPackageDir, "bin/eslint.js"));

--- a/src/app/layouts/Layout.astro
+++ b/src/app/layouts/Layout.astro
@@ -68,6 +68,17 @@ try {
   faviconPath = '/favicon.png';
 }
 
+
+let docsManifestJson = '[]';
+try {
+  const manifestPath = path.join(process.cwd(), 'public/data/docs/manifest.json');
+  if (fs.existsSync(manifestPath)) {
+    docsManifestJson = fs.readFileSync(manifestPath, 'utf-8');
+  }
+} catch {
+  docsManifestJson = '[]';
+}
+
 const faviconType = faviconPath.endsWith('.svg')
   ? 'image/svg+xml'
   : faviconPath.endsWith('.ico')
@@ -189,6 +200,12 @@ const articleJsonLd = type === 'article' ? JSON.stringify({
     <link rel="icon"             href={faviconPath} type={faviconType} />
     <link rel="apple-touch-icon" href={faviconPath} />
 
+
+    <!-- Preload docs manifest for instant navigation without an extra render loader -->
+    <script is:inline define:vars={{ docsManifestJson }}>
+      window.__HUB_DOC_MANIFEST__ = JSON.parse(docsManifestJson);
+    </script>
+
     <!-- Astro SPA transitions -->
     <ClientRouter />
 
@@ -242,7 +259,7 @@ const articleJsonLd = type === 'article' ? JSON.stringify({
       </ThemeProvider>
     </ErrorBoundary>
 
-    <DevPanelLoader client:only="react" />
+    {import.meta.env.DEV && <DevPanelLoader client:only="react" />}
 
     <!-- Re-apply theme after SPA navigation -->
     <script is:inline>

--- a/src/app/pages/[...slug].astro
+++ b/src/app/pages/[...slug].astro
@@ -71,5 +71,5 @@ if (!doc || !slug) return Astro.redirect('/404');
       <article set:html={doc.content ?? ''} />
     </main>
   </noscript>
-  <DocContent client:only="react" doc={doc} />
+  <DocContent client:load doc={doc} />
 </Layout>

--- a/src/app/pages/index.astro
+++ b/src/app/pages/index.astro
@@ -127,7 +127,7 @@ const lang        = useLanding ? 'ru' : (welcomeDoc?.lang || 'ru');
       <GeneralPageWrapper client:only="react" />
     </>
   ) : welcomeDoc ? (
-    <DocContent client:only="react" doc={welcomeDoc} />
+    <DocContent client:load doc={welcomeDoc} />
   ) : (
     <div style="min-height:100vh;display:flex;align-items:center;justify-content:center;">
       <p>Загрузка...</p>

--- a/src/features/docs/hooks/useDocuments.ts
+++ b/src/features/docs/hooks/useDocuments.ts
@@ -1,5 +1,11 @@
 import { useState, useEffect } from 'react';
 
+declare global {
+  interface Window {
+    __HUB_DOC_MANIFEST__?: DocMetadata[];
+  }
+}
+
 export interface DocMetadata {
   id: string;
   title: string;
@@ -27,12 +33,21 @@ export interface UseManifestResult {
   error: string | null;
 }
 
+function getPreloadedManifest(): DocMetadata[] {
+  if (globalThis.window === undefined) return [];
+  return Array.isArray(globalThis.window.__HUB_DOC_MANIFEST__)
+    ? globalThis.window.__HUB_DOC_MANIFEST__
+    : [];
+}
+
 export function useManifest(): UseManifestResult {
-  const [manifest, setManifest] = useState<DocMetadata[]>([]);
-  const [loading, setLoading]   = useState(true);
+  const [manifest, setManifest] = useState<DocMetadata[]>(() => getPreloadedManifest());
+  const [loading, setLoading]   = useState(() => getPreloadedManifest().length === 0);
   const [error, setError]       = useState<string | null>(null);
 
   useEffect(() => {
+    if (manifest.length > 0) return;
+
     fetch('/data/docs/manifest.json')
       .then(res => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -47,7 +62,7 @@ export function useManifest(): UseManifestResult {
         setError(String(err));
         setLoading(false);
       });
-  }, []);
+  }, [manifest.length]);
 
   return { manifest, loading, error };
 }

--- a/src/features/ui-components/ComponentWrapper.tsx
+++ b/src/features/ui-components/ComponentWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, CSSProperties } from 'react';
+import React, { useMemo, type CSSProperties } from 'react';
 import type { UniversalProps } from './types';
 
 interface ComponentWrapperProps extends UniversalProps {

--- a/src/features/ui-components/beams/beams.tsx
+++ b/src/features/ui-components/beams/beams.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useMemo, FC } from 'react';
+import { useEffect, useRef, useMemo, type FC } from 'react';
 import * as THREE from 'three';
 
 // ─── Types ────────────────────────────────────────────────────────────────────

--- a/src/features/ui-components/silk/silk.tsx
+++ b/src/features/ui-components/silk/silk.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useEffect, FC } from 'react';
+import React, { useMemo, useRef, useEffect, type FC } from 'react';
 import * as THREE from 'three';
 
 // ─── Types ────────────────────────────────────────────────────────────────────

--- a/src/features/ui-components/text-type/text-type.tsx
+++ b/src/features/ui-components/text-type/text-type.tsx
@@ -1,4 +1,4 @@
-import { ElementType, useEffect, useRef, useState, createElement, useMemo, useCallback } from 'react';
+import { type ElementType, useEffect, useRef, useState, createElement, useMemo, useCallback } from 'react';
 import { gsap } from 'gsap';
 
 interface TextTypeProps {

--- a/src/shared/components/Overlay.tsx
+++ b/src/shared/components/Overlay.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, ReactNode } from 'react';
+import React, { useEffect, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
 interface OverlayProps {

--- a/src/shared/lib/htmlParser.tsx
+++ b/src/shared/lib/htmlParser.tsx
@@ -610,6 +610,15 @@ const processElement = (
 };
 
 export const parseHtmlToReact = (html: string): React.ReactNode[] => {
+  if (typeof DOMParser === 'undefined') {
+    return [
+      React.createElement('div', {
+        key: 'ssr-html',
+        dangerouslySetInnerHTML: { __html: sanitizeHtml(html) },
+      }),
+    ];
+  }
+
   const rawDoc = new DOMParser().parseFromString(html, 'text/html');
 
   // KaTeX-элементы сохраняются до санитизации, т.к. DOMPurify может изменить их разметку.


### PR DESCRIPTION
### Motivation
- Reduce client fetch latency for docs by preloading the manifest into the initial HTML to enable instant navigation without extra loader renders.  
- Improve client-side loading behavior for heavy doc content and ensure SPA dev tooling only runs in development.  
- Harden SSR/Node environments and tidy TypeScript imports to avoid runtime/import side-effects.

### Description
- Added reading of `public/data/docs/manifest.json` in the main layout and inlined it into `window.__HUB_DOC_MANIFEST__` via an inline script for preloading.  
- Updated `useManifest` hook to consume the preloaded manifest on initialization and skip the network fetch when preloaded data exists.  
- Switched doc pages/components to `client:load` for `DocContent` and gated `DevPanelLoader` to `import.meta.env.DEV` to avoid running dev UI in production.  
- Added an SSR-safe fallback in `parseHtmlToReact` to return sanitized HTML when `DOMParser` is unavailable, adjusted a number of React imports to `type`-only imports, and added small runtime fixes (e.g. resolving `eslint` bin path via `require.resolve` in the runner).

### Testing
- Ran the project lint and build commands with `npm run lint` and `npm run build`, which completed successfully.  
- Started the dev server with `npm run dev` and validated that the inlined manifest is present in the page source and that `DocContent` loads on navigation.  
- Verified no type errors surfaced from the TypeScript checks during the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f9eb40fe8832fb7c1ad8107a9deb2)