### PR TITLE
Preload docs manifest, add static shells for SSR/SPA handoff, and fix ESLint runner path/types

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -7,7 +7,7 @@
   <!-- Главная страница -->
   <url>
     <loc>https://opensophy.com/</loc>
-    <lastmod>2026-06-02</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/scripts/eslint-runner.cjs
+++ b/scripts/eslint-runner.cjs
@@ -2,9 +2,11 @@
 "use strict";
 
 const Module = require("node:module");
+const path = require("node:path");
 
 if (typeof Module.enableCompileCache === "function") {
   Module.enableCompileCache = () => ({ status: "DISABLED_BY_RUNNER" });
 }
 
-require("eslint/bin/eslint.js");
+const eslintPackageDir = path.dirname(require.resolve("eslint/package.json"));
+require(path.join(eslintPackageDir, "bin/eslint.js"));

--- a/src/app/layouts/Layout.astro
+++ b/src/app/layouts/Layout.astro
@@ -20,6 +20,7 @@ interface Props {
   keywords?: string;
   robots?: string;
   lang?: string;
+  preloadDocsManifest?: boolean;
 }
 
 const SITE = {
@@ -48,6 +49,7 @@ const {
   keywords    = SITE.keywords,
   robots      = 'index, follow',
   lang        = SITE.lang,
+  preloadDocsManifest = false,
 } = Astro.props;
 
 const pageTitle    = title === SITE.name ? title : `${title} — ${SITE.name}`;
@@ -66,6 +68,18 @@ try {
   }
 } catch {
   faviconPath = '/favicon.png';
+}
+
+let docsManifestJson = '[]';
+if (preloadDocsManifest) {
+  try {
+    const manifestPath = path.join(process.cwd(), 'public/data/docs/manifest.json');
+    if (fs.existsSync(manifestPath)) {
+      docsManifestJson = fs.readFileSync(manifestPath, 'utf-8');
+    }
+  } catch {
+    docsManifestJson = '[]';
+  }
 }
 
 const faviconType = faviconPath.endsWith('.svg')
@@ -189,6 +203,15 @@ const articleJsonLd = type === 'article' ? JSON.stringify({
     <link rel="icon"             href={faviconPath} type={faviconType} />
     <link rel="apple-touch-icon" href={faviconPath} />
 
+    {preloadDocsManifest && (
+      <>
+        <!-- Preload docs manifest only on document pages, not on the landing page -->
+        <script is:inline define:vars={{ docsManifestJson }}>
+          window.__HUB_DOC_MANIFEST__ = JSON.parse(docsManifestJson);
+        </script>
+      </>
+    )}
+
     <!-- Astro SPA transitions -->
     <ClientRouter />
 
@@ -242,7 +265,7 @@ const articleJsonLd = type === 'article' ? JSON.stringify({
       </ThemeProvider>
     </ErrorBoundary>
 
-    <DevPanelLoader client:only="react" />
+    {import.meta.env.DEV && <DevPanelLoader client:only="react" />}
 
     <!-- Re-apply theme after SPA navigation -->
     <script is:inline>

--- a/src/app/pages/[...slug].astro
+++ b/src/app/pages/[...slug].astro
@@ -65,11 +65,19 @@ if (!doc || !slug) return Astro.redirect('/404');
   keywords={doc.keywords}
   robots={doc.robots}
   lang={doc.lang || 'ru'}
+  preloadDocsManifest={true}
 >
-  <noscript>
-    <main style="max-width: 980px; margin: 0 auto; padding: 2rem 1rem;">
+  <div id="doc-static-shell" style="min-height:100vh;background:#0a0a0a;color:#e8e8e8;">
+    <main style="max-width: 980px; margin: 0 auto; padding: 2rem 1rem 4rem;">
+      <header style="padding:1rem 0 2rem;border-bottom:1px solid rgba(255,255,255,0.12);margin-bottom:2rem;">
+        <h1 style="font-size:clamp(1.8rem,5vw,3rem);line-height:1.15;margin:0 0 1rem;font-family:system-ui,-apple-system,sans-serif;">{doc.title}</h1>
+        {doc.description && <p style="font-size:1rem;line-height:1.65;margin:0;color:rgba(255,255,255,0.72);">{doc.description}</p>}
+      </header>
       <article set:html={doc.content ?? ''} />
     </main>
+  </div>
+  <noscript>
+    <style>#doc-static-shell{display:block!important}</style>
   </noscript>
   <DocContent client:only="react" doc={doc} />
 </Layout>

--- a/src/app/pages/index.astro
+++ b/src/app/pages/index.astro
@@ -53,6 +53,7 @@ const lang        = useLanding ? 'ru' : (welcomeDoc?.lang || 'ru');
   keywords={keywords}
   robots="index, follow"
   lang={lang}
+  preloadDocsManifest={!useLanding && !!welcomeDoc}
 >
   {useLanding ? (
     <>
@@ -124,9 +125,33 @@ const lang        = useLanding ? 'ru' : (welcomeDoc?.lang || 'ru');
         </section>
       </article>
 
-      <GeneralPageWrapper client:only="react" />
+      <section
+        id="landing-static-shell"
+        style="min-height:100vh;background:#0a0a0a;color:#fff;padding:clamp(3rem,9vw,7rem) clamp(1.25rem,6vw,5rem);box-sizing:border-box;font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;"
+      >
+        <div style="max-width:1120px;margin:0 auto;">
+          <p style="margin:0 0 1rem;color:rgba(255,255,255,0.58);font-size:0.82rem;letter-spacing:0.14em;text-transform:uppercase;font-weight:700;">Opensophy</p>
+          <h1 style="margin:0;font-size:clamp(2.4rem,10vw,7rem);line-height:0.95;letter-spacing:-0.07em;font-weight:700;">Качественные IT-знания, безопасность и open-source инструменты</h1>
+          <p style="max-width:760px;margin:1.5rem 0 0;color:rgba(255,255,255,0.72);font-size:clamp(1rem,2vw,1.35rem);line-height:1.6;">{LANDING_DESCRIPTION}</p>
+          <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:1rem;margin-top:clamp(2rem,5vw,4rem);">
+            <article style="border:1px solid rgba(255,255,255,0.12);border-radius:18px;padding:1.2rem;background:rgba(255,255,255,0.04);"><h2 style="margin:0 0 .6rem;font-size:1rem;">Открытые знания</h2><p style="margin:0;color:rgba(255,255,255,.65);line-height:1.55;">Статьи и гайды по DevSecOps, Linux, разработке и инфраструктуре.</p></article>
+            <article style="border:1px solid rgba(255,255,255,0.12);border-radius:18px;padding:1.2rem;background:rgba(255,255,255,0.04);"><h2 style="margin:0 0 .6rem;font-size:1rem;">Безопасность</h2><p style="margin:0;color:rgba(255,255,255,.65);line-height:1.55;">SAST, DAST, SCA, mTLS, VPN, Zero Trust и проверка защищённости.</p></article>
+            <article style="border:1px solid rgba(255,255,255,0.12);border-radius:18px;padding:1.2rem;background:rgba(255,255,255,0.04);"><h2 style="margin:0 0 .6rem;font-size:1rem;">Инструменты</h2><p style="margin:0;color:rgba(255,255,255,.65);line-height:1.55;">Open-source решения для современных IT-команд и инфраструктуры.</p></article>
+          </div>
+        </div>
+      </section>
+      <GeneralPageWrapper client:idle />
     </>
   ) : welcomeDoc ? (
+    <div id="doc-static-shell" style="min-height:100vh;background:#0a0a0a;color:#e8e8e8;">
+      <main style="max-width: 980px; margin: 0 auto; padding: 2rem 1rem 4rem;">
+        <header style="padding:1rem 0 2rem;border-bottom:1px solid rgba(255,255,255,0.12);margin-bottom:2rem;">
+          <h1 style="font-size:clamp(1.8rem,5vw,3rem);line-height:1.15;margin:0 0 1rem;font-family:system-ui,-apple-system,sans-serif;">{welcomeDoc.title}</h1>
+          {welcomeDoc.description && <p style="font-size:1rem;line-height:1.65;margin:0;color:rgba(255,255,255,0.72);">{welcomeDoc.description}</p>}
+        </header>
+        <article set:html={welcomeDoc.content ?? ''} />
+      </main>
+    </div>
     <DocContent client:only="react" doc={welcomeDoc} />
   ) : (
     <div style="min-height:100vh;display:flex;align-items:center;justify-content:center;">

--- a/src/features/docs/components/DocContent.tsx
+++ b/src/features/docs/components/DocContent.tsx
@@ -174,6 +174,10 @@ const DocHero: React.FC<DocHeroProps> = ({ doc, isDark, readTime, liveFM, showDo
 
 const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
   const { isDark } = useTheme();
+
+  useEffect(() => {
+    document.getElementById('doc-static-shell')?.remove();
+  }, []);
   const t = makeTokens(isDark);
   const [fullscreenTableHtml, setFullscreenTableHtml] = useState<string | null>(null);
   const [showDotWaveBackground, setShowDotWaveBackground] = useState(true);

--- a/src/features/docs/hooks/useDocuments.ts
+++ b/src/features/docs/hooks/useDocuments.ts
@@ -1,5 +1,11 @@
 import { useState, useEffect } from 'react';
 
+declare global {
+  interface Window {
+    __HUB_DOC_MANIFEST__?: DocMetadata[];
+  }
+}
+
 export interface DocMetadata {
   id: string;
   title: string;
@@ -27,12 +33,21 @@ export interface UseManifestResult {
   error: string | null;
 }
 
+function getPreloadedManifest(): DocMetadata[] {
+  if (globalThis.window === undefined) return [];
+  return Array.isArray(globalThis.window.__HUB_DOC_MANIFEST__)
+    ? globalThis.window.__HUB_DOC_MANIFEST__
+    : [];
+}
+
 export function useManifest(): UseManifestResult {
-  const [manifest, setManifest] = useState<DocMetadata[]>([]);
-  const [loading, setLoading]   = useState(true);
+  const [manifest, setManifest] = useState<DocMetadata[]>(() => getPreloadedManifest());
+  const [loading, setLoading]   = useState(() => getPreloadedManifest().length === 0);
   const [error, setError]       = useState<string | null>(null);
 
   useEffect(() => {
+    if (manifest.length > 0) return;
+
     fetch('/data/docs/manifest.json')
       .then(res => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -47,7 +62,7 @@ export function useManifest(): UseManifestResult {
         setError(String(err));
         setLoading(false);
       });
-  }, []);
+  }, [manifest.length]);
 
   return { manifest, loading, error };
 }

--- a/src/features/general/components/GeneralPage.tsx
+++ b/src/features/general/components/GeneralPage.tsx
@@ -1493,11 +1493,17 @@ const LandingContent: React.FC = () => {
 
 // ─── GeneralPage ──────────────────────────────────────────────────────────────
 
-const GeneralPage: React.FC = () => (
-  <ThemeProvider>
-    <LandingContent />
-  </ThemeProvider>
-);
+const GeneralPage: React.FC = () => {
+  useEffect(() => {
+    document.getElementById('landing-static-shell')?.remove();
+  }, []);
+
+  return (
+    <ThemeProvider>
+      <LandingContent />
+    </ThemeProvider>
+  );
+};
 
 export { ShinyText, GlowingEffectInline, FeatureCard };
 export default GeneralPage;

--- a/src/features/ui-components/ComponentWrapper.tsx
+++ b/src/features/ui-components/ComponentWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, CSSProperties } from 'react';
+import React, { useMemo, type CSSProperties } from 'react';
 import type { UniversalProps } from './types';
 
 interface ComponentWrapperProps extends UniversalProps {

--- a/src/features/ui-components/beams/beams.tsx
+++ b/src/features/ui-components/beams/beams.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useMemo, FC } from 'react';
+import { useEffect, useRef, useMemo, type FC } from 'react';
 import * as THREE from 'three';
 
 // ─── Types ────────────────────────────────────────────────────────────────────

--- a/src/features/ui-components/silk/silk.tsx
+++ b/src/features/ui-components/silk/silk.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useEffect, FC } from 'react';
+import React, { useMemo, useRef, useEffect, type FC } from 'react';
 import * as THREE from 'three';
 
 // ─── Types ────────────────────────────────────────────────────────────────────

--- a/src/features/ui-components/text-type/text-type.tsx
+++ b/src/features/ui-components/text-type/text-type.tsx
@@ -1,4 +1,4 @@
-import { ElementType, useEffect, useRef, useState, createElement, useMemo, useCallback } from 'react';
+import { type ElementType, useEffect, useRef, useState, createElement, useMemo, useCallback } from 'react';
 import { gsap } from 'gsap';
 
 interface TextTypeProps {

--- a/src/shared/components/Overlay.tsx
+++ b/src/shared/components/Overlay.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, ReactNode } from 'react';
+import React, { useEffect, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
 interface OverlayProps {


### PR DESCRIPTION
### Motivation
- Improve initial page load and SPA handoff by inlining the docs manifest for doc pages and rendering minimal static shells for landing and doc pages to avoid content flash during hydration.
- Ensure the ESLint runner resolves the packaged binary reliably when executed from the runner script.
- Tighten TypeScript React imports and enable client-side cleanup of server-rendered static shells after hydration.

### Description
- Added `preloadDocsManifest` prop to `Layout.astro` and logic to read `public/data/docs/manifest.json` server-side and inline it into `window.__HUB_DOC_MANIFEST__` when enabled.
- Updated `src/app/pages/index.astro` and `src/app/pages/[...slug].astro` to enable `preloadDocsManifest` appropriately and to render lightweight static shells for the landing and document pages (with `noscript` fallbacks) to improve perceived load and SEO.
- Modified client components `DocContent` and `GeneralPage` to remove the server-rendered static shell DOM nodes on mount via `useEffect` to avoid duplicate content after hydration.
- Enhanced `useManifest` hook to read a preloaded manifest from `window.__HUB_DOC_MANIFEST__`, initialize loading state appropriately, and skip fetching when the preloaded manifest exists.
- Adjusted `DevPanelLoader` to only load in dev mode (`import.meta.env.DEV`) and changed `GeneralPageWrapper` usage to `client:idle` in the landing flow.
- Fixed the ESLint runner `scripts/eslint-runner.cjs` to resolve the `eslint` package directory via `require.resolve('eslint/package.json')` and require the packaged `bin/eslint.js` using `path.join`.
- Replaced several React imports to use `type` imports for TS (`type CSSProperties`, `type FC`, `type ElementType`, `type ReactNode`) to improve type-only import semantics.

### Testing
- Ran TypeScript type-check with `tsc --noEmit` which completed successfully.
- Executed project build `npm run build` and local dev preview which completed without errors.
- Ran linting via `npm run lint` (uses ESLint runner) and verified no new lint failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f9eb40fe8832fb7c1ad8107a9deb2)