### PR TITLE
Add configurable first-visit intro loader

### DIFF
--- a/public/data/site-config.json
+++ b/public/data/site-config.json
@@ -3,5 +3,6 @@
   "showDotWaveBackground": false,
   "favicon": "/favicon.png",
   "lightLogo": "/light_logo.png",
-  "darkLogo": "/dark_logo.png"
+  "darkLogo": "/dark_logo.png",
+  "introLoaderText": "opensophy"
 }

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -7,7 +7,7 @@
   <!-- Главная страница -->
   <url>
     <loc>https://opensophy.com/</loc>
-    <lastmod>2026-06-02</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/scripts/devBridge.mjs
+++ b/scripts/devBridge.mjs
@@ -75,6 +75,9 @@ function normalizeSiteConfig(config) {
     favicon: typeof config.favicon === 'string' && config.favicon ? config.favicon : '/favicon.png',
     lightLogo: typeof config.lightLogo === 'string' ? config.lightLogo : '',
     darkLogo: typeof config.darkLogo === 'string' ? config.darkLogo : '',
+    introLoaderText: typeof config.introLoaderText === 'string' && config.introLoaderText.trim()
+      ? config.introLoaderText.trim()
+      : 'opensophy',
   };
 }
 

--- a/src/app/layouts/Layout.astro
+++ b/src/app/layouts/Layout.astro
@@ -58,14 +58,19 @@ const updatedISO   = updated ? new Date(updated).toISOString() : publishedISO;
 const isHomePage   = url === '/';
 
 let faviconPath = '/favicon.png';
+let introLoaderText = 'opensophy';
 try {
   const siteConfigPath = path.join(process.cwd(), 'public/data/site-config.json');
   if (fs.existsSync(siteConfigPath)) {
     const cfg = JSON.parse(fs.readFileSync(siteConfigPath, 'utf-8'));
     if (typeof cfg.favicon === 'string' && cfg.favicon) faviconPath = cfg.favicon;
+    if (typeof cfg.introLoaderText === 'string' && cfg.introLoaderText.trim()) {
+      introLoaderText = cfg.introLoaderText.trim();
+    }
   }
 } catch {
   faviconPath = '/favicon.png';
+  introLoaderText = 'opensophy';
 }
 
 const faviconType = faviconPath.endsWith('.svg')
@@ -137,9 +142,22 @@ const articleJsonLd = type === 'article' ? JSON.stringify({
       (function () {
         var t = localStorage.getItem('theme') || 'dark';
         var d = t !== 'light';
+        var root = document.documentElement;
+        var overrides = null;
+        try { overrides = JSON.parse(localStorage.getItem('hub:theme-color-overrides') || 'null'); } catch (_) {}
+        if (overrides) {
+          ['dark', 'light'].forEach(function (mode) {
+            var colors = overrides[mode] || {};
+            Object.keys(colors).forEach(function (key) {
+              if (colors[key]) root.style.setProperty('--hub-theme-' + mode + '-' + key, colors[key]);
+            });
+          });
+        }
         document.documentElement.classList.toggle('dark', d);
         document.documentElement.style.colorScheme = d ? 'dark' : 'light';
-        document.documentElement.style.backgroundColor = d ? '#0a0a0a' : '#E8E7E3';
+        document.documentElement.style.backgroundColor = d
+          ? 'var(--hub-theme-dark-bgPage, #0a0a0a)'
+          : 'var(--hub-theme-light-bgPage, #E8E7E3)';
       })();
     </script>
 
@@ -222,6 +240,83 @@ const articleJsonLd = type === 'article' ? JSON.stringify({
       html.dark        { background-color: #0a0a0a; }
       body { margin: 0; padding: 0; overflow-x: hidden; }
 
+      #hub-intro-loader {
+        position: fixed;
+        inset: 0;
+        z-index: 2147483647;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--hub-theme-light-bgPage, #E8E7E3);
+        color: var(--hub-theme-light-fg, #111111);
+        opacity: 1;
+        transition: opacity 1.05s ease;
+        pointer-events: all;
+      }
+      html.dark #hub-intro-loader {
+        background: var(--hub-theme-dark-bgPage, #0a0a0a);
+        color: var(--hub-theme-dark-fg, #e8e8e8);
+      }
+      #hub-intro-loader.is-hiding { opacity: 0; }
+      #hub-intro-loader[hidden],
+      html.hub-intro-loader-skip #hub-intro-loader { display: none; }
+      .hub-intro-loader__inner {
+        width: min(78vw, 360px);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 22px;
+      }
+      .hub-intro-loader__title {
+        margin: 0;
+        font-size: clamp(2.2rem, 10vw, 5.4rem);
+        font-weight: 700;
+        letter-spacing: -0.065em;
+        line-height: 0.9;
+        background-image: linear-gradient(110deg, currentColor 0%, currentColor 36%, rgba(255,255,255,0.98) 50%, currentColor 64%, currentColor 100%);
+        background-size: 220% 100%;
+        background-position: 150% center;
+        background-clip: text;
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        animation: hubIntroShine 1.65s linear infinite;
+      }
+      html:not(.dark) .hub-intro-loader__title {
+        background-image: linear-gradient(110deg, currentColor 0%, currentColor 36%, rgba(255,255,255,0.95) 48%, rgba(0,0,0,0.84) 52%, currentColor 66%, currentColor 100%);
+      }
+      .hub-intro-loader__track {
+        width: 100%;
+        height: 4px;
+        overflow: hidden;
+        border-radius: 999px;
+        background: var(--hub-theme-light-accentSoft, rgba(0,0,0,0.07));
+      }
+      html.dark .hub-intro-loader__track {
+        background: var(--hub-theme-dark-accentSoft, rgba(255,255,255,0.08));
+      }
+      .hub-intro-loader__bar {
+        display: block;
+        width: 100%;
+        height: 100%;
+        border-radius: inherit;
+        background: var(--hub-theme-light-accent, #000000);
+        transform-origin: left center;
+        transform: scaleX(var(--hub-intro-progress, 0.08));
+        transition: transform 260ms cubic-bezier(.22,.61,.36,1);
+      }
+      html.dark .hub-intro-loader__bar {
+        background: var(--hub-theme-dark-accent, #ffffff);
+      }
+      @keyframes hubIntroShine {
+        from { background-position: 150% center; }
+        to { background-position: -70% center; }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        #hub-intro-loader { transition-duration: 250ms; }
+        .hub-intro-loader__title { animation: none; }
+        .hub-intro-loader__bar { transition-duration: 120ms; }
+      }
+
       /* Скрытый SEO-контент — видим для ботов, невидим для пользователей */
       #seo-landing-content {
         position: absolute;
@@ -236,6 +331,56 @@ const articleJsonLd = type === 'article' ? JSON.stringify({
   </head>
 
   <body>
+    <script is:inline>
+      (function () {
+        var key = 'hub:intro-loader-shown';
+        var shouldShow = true;
+        try { shouldShow = sessionStorage.getItem(key) !== '1'; } catch (_) {}
+        if (!shouldShow) document.documentElement.classList.add('hub-intro-loader-skip');
+        else { try { sessionStorage.setItem(key, '1'); } catch (_) {} }
+      })();
+    </script>
+    <div id="hub-intro-loader" aria-label="Загрузка сайта" role="status">
+      <div class="hub-intro-loader__inner">
+        <p class="hub-intro-loader__title">{introLoaderText}</p>
+        <div class="hub-intro-loader__track" aria-hidden="true"><span class="hub-intro-loader__bar"></span></div>
+      </div>
+    </div>
+    <script is:inline>
+      (function () {
+        var loader = document.getElementById('hub-intro-loader');
+        if (!loader) return;
+        if (document.documentElement.classList.contains('hub-intro-loader-skip')) {
+          loader.remove();
+          return;
+        }
+        var progress = 0.08;
+        var done = false;
+        var setProgress = function (value) {
+          progress = Math.max(progress, Math.min(value, 1));
+          loader.style.setProperty('--hub-intro-progress', String(progress));
+        };
+        var timer = window.setInterval(function () {
+          if (done) return;
+          var limit = document.readyState === 'interactive' ? 0.86 : 0.72;
+          setProgress(progress + (limit - progress) * 0.08 + 0.006);
+        }, 120);
+        var hide = function () {
+          if (done) return;
+          done = true;
+          window.clearInterval(timer);
+          setProgress(1);
+          window.setTimeout(function () {
+            loader.classList.add('is-hiding');
+            window.setTimeout(function () { loader.remove(); }, 1150);
+          }, 180);
+        };
+        if (document.readyState === 'complete') hide();
+        else window.addEventListener('load', hide, { once: true });
+        window.addEventListener('pagehide', function () { window.clearInterval(timer); }, { once: true });
+      })();
+    </script>
+
     <ErrorBoundary>
       <ThemeProvider>
         <slot />
@@ -249,9 +394,22 @@ const articleJsonLd = type === 'article' ? JSON.stringify({
       document.addEventListener('astro:after-swap', function () {
         var t = localStorage.getItem('theme') || 'dark';
         var d = t !== 'light';
+        var root = document.documentElement;
+        var overrides = null;
+        try { overrides = JSON.parse(localStorage.getItem('hub:theme-color-overrides') || 'null'); } catch (_) {}
+        if (overrides) {
+          ['dark', 'light'].forEach(function (mode) {
+            var colors = overrides[mode] || {};
+            Object.keys(colors).forEach(function (key) {
+              if (colors[key]) root.style.setProperty('--hub-theme-' + mode + '-' + key, colors[key]);
+            });
+          });
+        }
         document.documentElement.classList.toggle('dark', d);
         document.documentElement.style.colorScheme = d ? 'dark' : 'light';
-        document.documentElement.style.backgroundColor = d ? '#0a0a0a' : '#E8E7E3';
+        document.documentElement.style.backgroundColor = d
+          ? 'var(--hub-theme-dark-bgPage, #0a0a0a)'
+          : 'var(--hub-theme-light-bgPage, #E8E7E3)';
       });
     </script>
   </body>

--- a/src/features/dev-panel/panels/SitePanel.tsx
+++ b/src/features/dev-panel/panels/SitePanel.tsx
@@ -76,7 +76,7 @@ function ModeButton({
 export default function SitePanel() {
   const t = useContext(ThemeTokensContext);
 
-  const [config, setConfig]   = useState<SiteConfig>({ useLanding: false, showDotWaveBackground: true });
+  const [config, setConfig]   = useState<SiteConfig>({ useLanding: false, showDotWaveBackground: true, introLoaderText: 'opensophy' });
   const [loading, setLoading] = useState(true);
   const [saving, setSaving]   = useState(false);
   const [error, setError]     = useState('');
@@ -99,6 +99,7 @@ export default function SitePanel() {
       setConfig({
         useLanding: cfg.useLanding === true,
         showDotWaveBackground: cfg.showDotWaveBackground !== false,
+        introLoaderText: typeof cfg.introLoaderText === 'string' && cfg.introLoaderText.trim() ? cfg.introLoaderText : 'opensophy',
       });
     } catch (e: unknown) {
       setError((e as Error).message);
@@ -177,6 +178,23 @@ export default function SitePanel() {
       { ...config, showDotWaveBackground: value },
       value ? 'Фон шапки включён' : 'Фон шапки отключён',
     );
+
+  const handleIntroLoaderTextBlur = () => {
+    const nextText = (config.introLoaderText || '').trim() || 'opensophy';
+    if (nextText === config.introLoaderText) return;
+    void applyConfigChange(
+      { ...config, introLoaderText: nextText },
+      'Текст загрузчика обновлён',
+    );
+  };
+
+  const handleIntroLoaderTextSave = () => {
+    const nextText = (config.introLoaderText || '').trim() || 'opensophy';
+    void applyConfigChange(
+      { ...config, introLoaderText: nextText },
+      'Текст загрузчика обновлён',
+    );
+  };
 
   if (loading) {
     return (
@@ -288,6 +306,52 @@ export default function SitePanel() {
         </button>
       </div>
 
+      {/* Отображение загрузчика */}
+      <div style={{ height: 1, background: t.border, margin: '12px 0' }} />
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, fontWeight: 700, color: t.fgSub, textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 8 }}>
+        ОТОБРАЖЕНИЕ ЗАГРУЗЧИКА
+      </div>
+      <div style={{
+        display: 'flex', flexDirection: 'column', gap: 8,
+        marginBottom: 12, padding: '10px 12px',
+        borderRadius: 7, border: `1px solid ${t.border}`, background: t.surface,
+      }}>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 6, fontSize: 12, color: t.fgMuted }}>
+          Текст intro loader
+          <input
+            type="text"
+            value={config.introLoaderText || 'opensophy'}
+            disabled={saving}
+            onChange={e => setConfig(prev => ({ ...prev, introLoaderText: e.target.value }))}
+            onBlur={handleIntroLoaderTextBlur}
+            placeholder="opensophy"
+            style={{
+              height: 34, background: t.bg, border: `1px solid ${t.border}`,
+              borderRadius: 7, color: t.fg, padding: '0 10px',
+              fontSize: 13, fontFamily: t.mono, outline: 'none',
+            }}
+          />
+        </label>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+          <span style={{ fontSize: 12, color: t.fgSub, lineHeight: 1.45 }}>
+            Используется на первом экране загрузки. Цвета берутся из текущих токенов темы.
+          </span>
+          <button
+            disabled={saving}
+            onClick={handleIntroLoaderTextSave}
+            style={{
+              flexShrink: 0, border: `1px solid ${t.borderStrong}`,
+              background: t.accentSoft, color: t.fg,
+              borderRadius: 6, padding: '7px 10px', fontSize: 12,
+              fontFamily: t.mono, cursor: saving ? 'not-allowed' : 'pointer',
+              opacity: saving ? 0.7 : 1,
+            }}
+          >
+            Сохранить
+          </button>
+        </div>
+      </div>
+
       {/* Текущее состояние */}
       <div style={{
         fontSize: 12, color: t.fgSub,
@@ -295,7 +359,7 @@ export default function SitePanel() {
       }}>
         <span>
           Сейчас: <strong style={{ color: t.fgMuted }}>
-            {config.useLanding ? 'Лендинг' : 'Документация'} · Фон шапки: {dotWaveEnabled ? 'вкл' : 'выкл'}
+            {config.useLanding ? 'Лендинг' : 'Документация'} · Фон шапки: {dotWaveEnabled ? 'вкл' : 'выкл'} · Loader: {config.introLoaderText || 'opensophy'}
           </strong>
         </span>
         <button

--- a/src/features/dev-panel/useDevBridge.ts
+++ b/src/features/dev-panel/useDevBridge.ts
@@ -161,6 +161,7 @@ export interface SiteConfig {
   favicon?: string;
   lightLogo?: string;
   darkLogo?: string;
+  introLoaderText?: string;
 }
 
 // ─── Typed bridge API ──────────────────────────────────────────────────────────

--- a/src/features/navigation/components/Navigation.tsx
+++ b/src/features/navigation/components/Navigation.tsx
@@ -500,13 +500,13 @@ const SectionDropdown: React.FC<{
 // ─── NavTreeContent ───────────────────────────────────────────────────────────
 
 const NavTreeContent: React.FC<{
-  error: boolean; loading: boolean; navTree: NavNode;
+  error: boolean; navTree: NavNode;
   currentDocSlug: string | undefined; expandedPaths: Set<string>;
   onToggle: (p: string) => void; isDark: boolean; mobile: boolean | undefined;
   activeNavSlug: string;
   onDocClick?: () => void;
   onDocHoverChange?: (payload: { doc: Doc; rect: DOMRect } | null) => void;
-}> = ({ error, loading, navTree, currentDocSlug, expandedPaths, onToggle, isDark, mobile, activeNavSlug, onDocClick, onDocHoverChange }) => {
+}> = ({ error, navTree, currentDocSlug, expandedPaths, onToggle, isDark, mobile, activeNavSlug, onDocClick, onDocHoverChange }) => {
   const t = tk(isDark);
 
   const isHomePage = globalThis.window?.location.pathname === '/';
@@ -523,8 +523,6 @@ const NavTreeContent: React.FC<{
       <button onClick={() => globalThis.location.reload()} style={{ padding: '0.35rem 0.85rem', borderRadius: '7px', border: `1px solid ${t.border}`, background: 'transparent', color: t.fgMuted, fontSize: mobile ? '0.9rem' : '0.75rem', cursor: 'pointer' }}>Обновить</button>
     </div>
   );
-  if (loading) return <div style={{ padding: '2rem', textAlign: 'center', fontSize: mobile ? '0.95rem' : '0.8rem', color: t.fgMuted }}>Загрузка...</div>;
-
   return (
     <nav style={{ display: 'flex', flexDirection: 'column', gap: '3px' }}>
       {activeNavSlug === '' && (
@@ -590,7 +588,7 @@ const NavPanelContent: React.FC<{
   isDark: boolean; currentDocSlug?: string; mobile?: boolean;
 }> = ({ isDark, currentDocSlug, mobile }) => {
   const t = tk(isDark);
-  const { manifest: docs, loading, error } = useManifest();
+  const { manifest: docs, error } = useManifest();
   const { query, setQuery, sectionOpen, setSectionOpen, sectionRef, sections, activeNavSlug, expandedPaths, navTree, activeSection, togglePath, handleSectionSelect } = useNavPanel(docs as Doc[], currentDocSlug);
 
   const inputFontSize = mobile ? '1rem' : '0.855rem';
@@ -669,7 +667,7 @@ const NavPanelContent: React.FC<{
       {/* Дерево навигации */}
       <div style={{ flex: 1, overflowY: 'auto', padding: mobile ? '8px 6px 86px' : '6px' }}>
         <NavTreeContent
-          error={!!error} loading={loading} navTree={navTree}
+          error={!!error} navTree={navTree}
           currentDocSlug={currentDocSlug} expandedPaths={expandedPaths}
           onToggle={togglePath} isDark={isDark} mobile={mobile}
           activeNavSlug={activeNavSlug}


### PR DESCRIPTION
### Motivation
- Provide a minimal, theme-aware intro screen that appears immediately on first full-page load and hides only after the page finishes loading. 
- Use existing theme tokens so the intro matches light/dark themes without duplicating colors. 
- Make the loader text configurable from site settings so admins can change the displayed word. 

### Description
- Inserted a lightweight inline intro into `src/app/layouts/Layout.astro` that renders before paint, uses CSS for a `Shiny` text effect and a progress bar, simulates progress until `window.load`, and fades out with `opacity` transition. 
- Read `introLoaderText` from `public/data/site-config.json` (default `opensophy`) and apply theme color overrides before paint so background/text colors use existing tokens. 
- Added `introLoaderText` support to the dev bridge and normalization in `scripts/devBridge.mjs` and typed it in `src/features/dev-panel/useDevBridge.ts`. 
- Added an admin UI block in `src/features/dev-panel/panels/SitePanel.tsx` under “ОТОБРАЖЕНИЕ ЗАГРУЗЧИКА” to edit and save `introLoaderText`, and removed the `Загрузка...` navigation placeholder so navigation chrome renders immediately while the manifest loads (`src/features/navigation/components/Navigation.tsx`). 

### Testing
- Ran `npm run build` which completed successfully and produced the static output. 
- Started the dev server (`npm run dev`) to exercise runtime behavior during development and observed build/generation steps complete. 
- `npm run lint` was attempted but is blocked by an existing ESLint package export issue in the environment and did not complete. 
- `npx tsc --noEmit` was attempted and fails due to unrelated, preexisting TypeScript errors in the repository (these are not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fa80c8fc88326a835d20110130024)