### PR TITLE
Speed up navigation manifest loading

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -7,7 +7,7 @@
   <!-- Главная страница -->
   <url>
     <loc>https://opensophy.com/</loc>
-    <lastmod>2026-06-02</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/src/features/docs/hooks/useDocuments.ts
+++ b/src/features/docs/hooks/useDocuments.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import initialManifest from '../../../../public/data/docs/manifest.json';
 
 export interface DocMetadata {
   id: string;
@@ -27,27 +27,8 @@ export interface UseManifestResult {
   error: string | null;
 }
 
+const docsManifest = initialManifest as DocMetadata[];
+
 export function useManifest(): UseManifestResult {
-  const [manifest, setManifest] = useState<DocMetadata[]>([]);
-  const [loading, setLoading]   = useState(true);
-  const [error, setError]       = useState<string | null>(null);
-
-  useEffect(() => {
-    fetch('/data/docs/manifest.json')
-      .then(res => {
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        return res.json() as Promise<DocMetadata[]>;
-      })
-      .then(data => {
-        setManifest(data);
-        setLoading(false);
-      })
-      .catch(err => {
-        console.error('[useManifest] Failed to load manifest:', err);
-        setError(String(err));
-        setLoading(false);
-      });
-  }, []);
-
-  return { manifest, loading, error };
+  return { manifest: docsManifest, loading: false, error: null };
 }

--- a/src/features/navigation/components/Navigation.tsx
+++ b/src/features/navigation/components/Navigation.tsx
@@ -500,13 +500,13 @@ const SectionDropdown: React.FC<{
 // ─── NavTreeContent ───────────────────────────────────────────────────────────
 
 const NavTreeContent: React.FC<{
-  error: boolean; loading: boolean; navTree: NavNode;
+  error: boolean; navTree: NavNode;
   currentDocSlug: string | undefined; expandedPaths: Set<string>;
   onToggle: (p: string) => void; isDark: boolean; mobile: boolean | undefined;
   activeNavSlug: string;
   onDocClick?: () => void;
   onDocHoverChange?: (payload: { doc: Doc; rect: DOMRect } | null) => void;
-}> = ({ error, loading, navTree, currentDocSlug, expandedPaths, onToggle, isDark, mobile, activeNavSlug, onDocClick, onDocHoverChange }) => {
+}> = ({ error, navTree, currentDocSlug, expandedPaths, onToggle, isDark, mobile, activeNavSlug, onDocClick, onDocHoverChange }) => {
   const t = tk(isDark);
 
   const isHomePage = globalThis.window?.location.pathname === '/';
@@ -523,8 +523,6 @@ const NavTreeContent: React.FC<{
       <button onClick={() => globalThis.location.reload()} style={{ padding: '0.35rem 0.85rem', borderRadius: '7px', border: `1px solid ${t.border}`, background: 'transparent', color: t.fgMuted, fontSize: mobile ? '0.9rem' : '0.75rem', cursor: 'pointer' }}>Обновить</button>
     </div>
   );
-  if (loading) return <div style={{ padding: '2rem', textAlign: 'center', fontSize: mobile ? '0.95rem' : '0.8rem', color: t.fgMuted }}>Загрузка...</div>;
-
   return (
     <nav style={{ display: 'flex', flexDirection: 'column', gap: '3px' }}>
       {activeNavSlug === '' && (
@@ -590,7 +588,7 @@ const NavPanelContent: React.FC<{
   isDark: boolean; currentDocSlug?: string; mobile?: boolean;
 }> = ({ isDark, currentDocSlug, mobile }) => {
   const t = tk(isDark);
-  const { manifest: docs, loading, error } = useManifest();
+  const { manifest: docs, error } = useManifest();
   const { query, setQuery, sectionOpen, setSectionOpen, sectionRef, sections, activeNavSlug, expandedPaths, navTree, activeSection, togglePath, handleSectionSelect } = useNavPanel(docs as Doc[], currentDocSlug);
 
   const inputFontSize = mobile ? '1rem' : '0.855rem';
@@ -669,7 +667,7 @@ const NavPanelContent: React.FC<{
       {/* Дерево навигации */}
       <div style={{ flex: 1, overflowY: 'auto', padding: mobile ? '8px 6px 86px' : '6px' }}>
         <NavTreeContent
-          error={!!error} loading={loading} navTree={navTree}
+          error={!!error} navTree={navTree}
           currentDocSlug={currentDocSlug} expandedPaths={expandedPaths}
           onToggle={togglePath} isDark={isDark} mobile={mobile}
           activeNavSlug={activeNavSlug}


### PR DESCRIPTION
### Motivation

- Make navigation available immediately on page render to improve load time on slow mobile networks by avoiding an extra runtime `fetch` for the docs manifest.
- Remove the visible navigation "Загрузка..." state so the nav renders as soon as the page hydrates and does not block UI with a fallback loading message.
- Reduce chance of double network requests and prioritize first-contentful paint for the navigation/search surface.

### Description

- Import the generated manifest JSON into the client bundle and expose it synchronously via `useManifest` (now returns the preloaded manifest with `loading: false`).
- Replace runtime `fetch('/data/docs/manifest.json')` logic with a direct import of `public/data/docs/manifest.json` in `src/features/docs/hooks/useDocuments.ts`.
- Remove the `loading` prop/state usage from `NavTreeContent` and delete the visible `Загрузка...` branch so the navigation tree renders immediately; update `NavPanelContent` to only use `manifest` and `error` from `useManifest`.
- Minor type/prop cleanup in `src/features/navigation/components/Navigation.tsx` to reflect the removed `loading` path.

### Testing

- Ran `npm run build` and the static site build completed successfully (`62 page(s) built`).
- Ran `npm run lint` and it failed in this environment due to the project lint runner referencing a non-exported ESLint subpath (`./bin/eslint.js`) under Node.js `v24.15.0`, not because of code changes in this PR.
- Verified local dev static generation (`node scripts/generate.mjs`) completed without errors during the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fab47f8ac8326934153fa105c4d3d)