### PR TITLE
Fix Navigation slug fallback for welcome docs page

### DIFF
--- a/public/data/site-config.json
+++ b/public/data/site-config.json
@@ -1,5 +1,5 @@
 {
-  "useLanding": false,
+  "useLanding": true,
   "showDotWaveBackground": false,
   "favicon": "/favicon.png",
   "lightLogo": "",

--- a/public/data/site-config.json
+++ b/public/data/site-config.json
@@ -1,7 +1,7 @@
 {
-  "useLanding": true,
+  "useLanding": false,
   "showDotWaveBackground": false,
   "favicon": "/favicon.png",
-  "lightLogo": "/light_logo.png",
-  "darkLogo": "/dark_logo.png"
+  "lightLogo": "",
+  "darkLogo": ""
 }

--- a/src/features/docs/components/DocContent.tsx
+++ b/src/features/docs/components/DocContent.tsx
@@ -310,7 +310,7 @@ const DocContentMain: React.FC<DocContentProps> = ({ doc }) => {
         style={{ position: 'fixed', top: 0, left: 0, height: '2px', width: '0%', background: t.accent, zIndex: 999, transition: 'none' }}
       />
 
-      <Navigation currentDocSlug={doc.slug} toc={toc} activeHeadingId={activeId} />
+      <Navigation currentDocSlug={doc.slug || 'welcome'} toc={toc} activeHeadingId={activeId} />
 
       <main
         className="min-h-screen"


### PR DESCRIPTION
### Motivation
- Prevent passing an empty slug into `Navigation` so the navigation chrome enables docs mode and applies docs-related CSS variables while keeping the root `/` page semantics unchanged.

### Description
- Replace the `Navigation` call in `src/features/docs/components/DocContent.tsx` to use a local fallback: `<Navigation currentDocSlug={doc.slug || 'welcome'} toc={toc} activeHeadingId={activeId} />`.

### Testing
- Ran `npm run lint` which completed with existing warnings only and no errors.
- Ran `npm run build` which succeeded and generated the static site.
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2837832f048330a137da84e10136fc)