### PR TITLE
Dev CMS: Bridge -> SSE middleware, Nav panel, and editor live preview

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,3 @@
 # Разрешённые хосты для bridge (через запятую)
 # По умолчанию только localhost
 BRIDGE_ALLOWED_HOSTS=localhost,127.0.0.1
-
-# Если запускаете astro dev --host для теста с телефона:
-# BRIDGE_ALLOWED_HOSTS=localhost,127.0.0.1,192.168.1.100

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,6 @@
+# Разрешённые хосты для bridge (через запятую)
+# По умолчанию только localhost
+BRIDGE_ALLOWED_HOSTS=localhost,127.0.0.1
+
+# Если запускаете astro dev --host для теста с телефона:
+# BRIDGE_ALLOWED_HOSTS=localhost,127.0.0.1,192.168.1.100

--- a/Docs/resume.md
+++ b/Docs/resume.md
@@ -5,5 +5,3 @@ icon: user
 priority: 3
 custom: resume
 ---
-
- 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,526 +1,68 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
-        http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-
-  <!-- Главная страница -->
-  <url>
-    <loc>https://opensophy.com/</loc>
-    <lastmod>2026-06-14</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/hub/general/</loc>
-    <lastmod>2026-06-03</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/linux/linux-files/</loc>
-    <lastmod>2026-05-26</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/linux/users-and-groups/</loc>
-    <lastmod>2026-05-11</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/linux/file-permissions/</loc>
-    <lastmod>2026-05-14</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/changelog/</loc>
-    <lastmod>2026-03-06</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/resume/</loc>
-    <lastmod>2026-06-14</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/linux/linux-processes/</loc>
-    <lastmod>2026-06-02</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/hub/custom-pages/</loc>
-    <lastmod>2026-06-09</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/general/</loc>
-    <lastmod>2026-06-03</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/plasma-wave/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/pixel-blast/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/gradient-blinds/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/iridescence/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/soft-aurora/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/eye-sauron/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/plasma/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/prism/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/dot-field/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/color-bends/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/grainient/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/prismatic-burst/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/aurora/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/light-rays/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/beams/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/silk/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/floating-lines/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/lightning/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/spoiler-text/</loc>
-    <lastmod>2026-05-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/light-pillar/</loc>
-    <lastmod>2026-05-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/fuzzy-text/</loc>
-    <lastmod>2026-05-06</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/development/devsecops-in-vibecode/</loc>
-    <lastmod>2026-05-01</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/morphing-text/</loc>
-    <lastmod>2026-04-25</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/rolling-text/</loc>
-    <lastmod>2026-04-25</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/line-shadow-text/</loc>
-    <lastmod>2026-04-25</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/wave-text/</loc>
-    <lastmod>2026-04-25</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/security/mtls/</loc>
-    <lastmod>2026-04-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/development/seo-geo-checklist/</loc>
-    <lastmod>2026-04-13</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/hub/homepage-system/</loc>
-    <lastmod>2026-04-12</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/security/cvss-guide/</loc>
-    <lastmod>2026-04-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/count-up/</loc>
-    <lastmod>2026-03-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/scroll-float/</loc>
-    <lastmod>2026-03-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/scroll-reveal/</loc>
-    <lastmod>2026-03-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/rotating-text/</loc>
-    <lastmod>2026-03-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/variable-proximity/</loc>
-    <lastmod>2026-03-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/scroll-velocity/</loc>
-    <lastmod>2026-03-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/dark-veil/</loc>
-    <lastmod>2026-03-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/gradient-text/</loc>
-    <lastmod>2026-03-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/curved-loop/</loc>
-    <lastmod>2026-03-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/split-text/</loc>
-    <lastmod>2026-03-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/circular-text/</loc>
-    <lastmod>2026-03-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/blur-text/</loc>
-    <lastmod>2026-03-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/shiny-text/</loc>
-    <lastmod>2026-03-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/decrypted-text/</loc>
-    <lastmod>2026-03-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/text-type/</loc>
-    <lastmod>2026-03-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/hub/frontmatter-guide/</loc>
-    <lastmod>2026-03-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/career/ats-hr/</loc>
-    <lastmod>2026-03-01</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/hub/markdown-guide/</loc>
-    <lastmod>2026-03-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/hub/component-guide/</loc>
-    <lastmod>2026-02-12</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/development/webrendering/</loc>
-    <lastmod>2026-02-12</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/tools-and-services/devsecops-tools/</loc>
-    <lastmod>2026-01-24</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/tools-and-services/dokploy/</loc>
-    <lastmod>2026-01-13</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/tools-and-services/vibecoders-and-web-developers-ui-components/</loc>
-    <lastmod>2026-01-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/career/career-tutorial/</loc>
-    <lastmod>2025-12-31</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/network-technologies/master-table-of-network-models-and-protocols/</loc>
-    <lastmod>2026-01-20</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/career/</loc>
-    <lastmod>2026-03-01</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/development/</loc>
-    <lastmod>2026-05-01</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/linux/</loc>
-    <lastmod>2026-06-02</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/network-technologies/</loc>
-    <lastmod>2026-01-20</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/security/</loc>
-    <lastmod>2026-04-21</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/article/tools-and-services/</loc>
-    <lastmod>2026-01-24</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/background/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/ui/typography/</loc>
-    <lastmod>2026-05-07</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <url>
-    <loc>https://opensophy.com/general/</loc>
-    <lastmod>2026-06-14</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://opensophy.com/</loc><lastmod>2026-06-14</lastmod><changefreq>weekly</changefreq><priority>1.0</priority></url>
+  <url><loc>https://opensophy.com/hub/general</loc><lastmod>2026-06-03</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/article/linux/linux-files</loc><lastmod>2026-05-26</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/article/linux/users-and-groups</loc><lastmod>2026-05-11</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/article/linux/file-permissions</loc><lastmod>2026-05-14</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/changelog</loc><lastmod>2026-03-06</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/resume</loc><lastmod>2026-06-14</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/article/linux/linux-processes</loc><lastmod>2026-06-02</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/hub/custom-pages</loc><lastmod>2026-06-09</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/general</loc><lastmod>2026-06-03</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/plasma-wave</loc><lastmod>2026-05-18</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/pixel-blast</loc><lastmod>2026-05-18</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/gradient-blinds</loc><lastmod>2026-05-18</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/iridescence</loc><lastmod>2026-05-18</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/soft-aurora</loc><lastmod>2026-05-18</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/eye-sauron</loc><lastmod>2026-05-18</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/plasma</loc><lastmod>2026-05-18</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/prism</loc><lastmod>2026-05-18</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/dot-field</loc><lastmod>2026-05-18</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/color-bends</loc><lastmod>2026-05-18</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/grainient</loc><lastmod>2026-05-18</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/prismatic-burst</loc><lastmod>2026-05-18</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/aurora</loc><lastmod>2026-05-18</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/light-rays</loc><lastmod>2026-05-18</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/beams</loc><lastmod>2026-05-18</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/silk</loc><lastmod>2026-05-18</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/floating-lines</loc><lastmod>2026-05-18</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/lightning</loc><lastmod>2026-05-18</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/spoiler-text</loc><lastmod>2026-05-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/light-pillar</loc><lastmod>2026-05-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/fuzzy-text</loc><lastmod>2026-05-06</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/article/development/devsecops-in-vibecode</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/morphing-text</loc><lastmod>2026-04-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/rolling-text</loc><lastmod>2026-04-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/line-shadow-text</loc><lastmod>2026-04-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/wave-text</loc><lastmod>2026-04-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/article/security/mtls</loc><lastmod>2026-04-21</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/article/development/seo-geo-checklist</loc><lastmod>2026-04-13</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/hub/homepage-system</loc><lastmod>2026-04-12</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/article/security/cvss-guide</loc><lastmod>2026-04-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/count-up</loc><lastmod>2026-03-23</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/scroll-float</loc><lastmod>2026-03-23</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/scroll-reveal</loc><lastmod>2026-03-23</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/rotating-text</loc><lastmod>2026-03-23</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/variable-proximity</loc><lastmod>2026-03-23</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/scroll-velocity</loc><lastmod>2026-03-23</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/background/dark-veil</loc><lastmod>2026-03-23</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/gradient-text</loc><lastmod>2026-03-22</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/curved-loop</loc><lastmod>2026-03-22</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/split-text</loc><lastmod>2026-03-22</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/circular-text</loc><lastmod>2026-03-22</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/blur-text</loc><lastmod>2026-03-22</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/shiny-text</loc><lastmod>2026-03-22</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/decrypted-text</loc><lastmod>2026-03-22</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/ui/typography/text-type</loc><lastmod>2026-03-22</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/hub/frontmatter-guide</loc><lastmod>2026-03-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/article/career/ats-hr</loc><lastmod>2026-03-01</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/hub/markdown-guide</loc><lastmod>2026-03-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/hub/component-guide</loc><lastmod>2026-02-12</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/article/development/webrendering</loc><lastmod>2026-02-12</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/article/tools-and-services/devsecops-tools</loc><lastmod>2026-01-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/article/tools-and-services/dokploy</loc><lastmod>2026-01-13</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/article/tools-and-services/vibecoders-and-web-developers-ui-components</loc><lastmod>2026-01-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/article/career/career-tutorial</loc><lastmod>2025-12-31</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://opensophy.com/article/network-technologies/master-table-of-network-models-and-protocols</loc><lastmod>2026-01-20</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
 </urlset>

--- a/scripts/bridgeHandlers.mjs
+++ b/scripts/bridgeHandlers.mjs
@@ -1,0 +1,415 @@
+/**
+ * Hub Dev Panel — WebSocket Bridge v4
+ */
+
+import fs   from 'node:fs';
+import path from 'node:path';
+
+export const ROOT       = process.cwd();
+export const DOCS_DIR   = path.join(ROOT, 'Docs');
+export const OUTPUT_DIR = path.join(ROOT, 'public/data/docs');
+export const MANIFEST   = path.join(OUTPUT_DIR, 'manifest.json');
+export const SITEMAP    = path.join(ROOT, 'public/sitemap.xml');
+export const SITE_CONFIG_PATH = path.join(ROOT, 'public/data/site-config.json');
+export const BASE_URL   = 'https://opensophy.com';
+
+// IPv4-mapped IPv6-адрес для localhost (::ffff:127.0.0.1) — стандартное представление Node.js
+const LOCALHOST_IPV4_MAPPED = '::ffff:127.0.0.1';
+
+// Адреса локального хоста, которым разрешено подключение
+const LOCALHOST_IPS = new Set(['::1', '127.0.0.1', LOCALHOST_IPV4_MAPPED]);
+
+// ─── Разрешённые пути ─────────────────────────────────────────────────────────
+
+const ALLOWED_WRITE = [
+  'Docs/',
+  'src/shared/data/',
+  'src/app/layouts/',
+  'src/app/pages/',
+  'public/',
+];
+const ALLOWED_READ = [
+  ...ALLOWED_WRITE,
+  'src/shared/data/contacts.ts',
+  'src/shared/data/seo.ts',
+];
+
+function relPath(abs) {
+  return path.relative(ROOT, abs).replaceAll('\\', '/');
+}
+function canWrite(absPath) {
+  const rel = relPath(absPath);
+  return ALLOWED_WRITE.some(p => rel.startsWith(p));
+}
+function canRead(absPath) {
+  const rel = relPath(absPath);
+  return ALLOWED_READ.some(p => rel === p || rel.startsWith(p));
+}
+
+function imageExtFromMime(mimeType) {
+  if (mimeType === 'image/svg+xml') return 'svg';
+  if (mimeType === 'image/x-icon' || mimeType === 'image/vnd.microsoft.icon') return 'ico';
+  if (mimeType === 'image/webp') return 'webp';
+  return 'png';
+}
+
+async function readSiteConfigFile() {
+  try {
+    if (!fs.existsSync(SITE_CONFIG_PATH)) return {};
+    return JSON.parse(await fs.promises.readFile(SITE_CONFIG_PATH, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+async function writeSiteConfigFile(config) {
+  await fs.promises.mkdir(path.dirname(SITE_CONFIG_PATH), { recursive: true });
+  await fs.promises.writeFile(SITE_CONFIG_PATH, JSON.stringify(config, null, 2), 'utf-8');
+}
+
+function normalizeSiteConfig(config) {
+  return {
+    useLanding: config.useLanding === true,
+    showDotWaveBackground: config.showDotWaveBackground !== false,
+    favicon: typeof config.favicon === 'string' && config.favicon ? config.favicon : '/favicon.png',
+    lightLogo: typeof config.lightLogo === 'string' ? config.lightLogo : '',
+    darkLogo: typeof config.darkLogo === 'string' ? config.darkLogo : '',
+  };
+}
+
+// ─── Загрузка утилит ──────────────────────────────────────────────────────────
+
+let _utils = null;
+
+async function loadUtils() {
+  const url = `${pathToFileURL(path.join(ROOT, 'scripts/docUtils.mjs'))}?bust=${Date.now()}`;
+  _utils = await import(url);
+  return _utils;
+}
+
+function pathToFileURL(p) {
+  return 'file:///' + p.replaceAll('\\', '/').replace(/^\//, '');
+}
+
+// ─── Генерация манифеста и sitemap ────────────────────────────────────────────
+
+export async function runGenerate() {
+  const { scanDocsDirectoryRecursive, buildDocFromPath } = await loadUtils();
+
+  if (!fs.existsSync(DOCS_DIR)) return { ok: false, stdout: '', stderr: 'Docs/ not found' };
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+
+  const allFiles = scanDocsDirectoryRecursive(DOCS_DIR);
+  const manifest = [];
+  const errors   = [];
+  const SKIP     = new Set(['content', 'keywords', 'robots']);
+
+  for (const mdPath of allFiles) {
+    try {
+      const doc   = buildDocFromPath(mdPath, DOCS_DIR);
+      const entry = Object.fromEntries(Object.entries(doc).filter(([k]) => !SKIP.has(k)));
+      manifest.push(entry);
+    } catch (err) {
+      errors.push(`${relPath(mdPath)}: ${err.message}`);
+    }
+  }
+
+  const sorted = [...manifest].sort((a, b) => {
+  const pa = a.priority ?? 999;
+  const pb = b.priority ?? 999;
+
+  if (pa !== pb) {
+    return pa - pb;
+  }
+
+  return new Date(b.date ?? 0).getTime() - new Date(a.date ?? 0).getTime();
+});
+
+  fs.writeFileSync(MANIFEST, JSON.stringify(sorted));
+
+  const today = new Date().toISOString().split('T')[0];
+  const urls = sorted
+    .filter(d => d.slug && d.slug !== 'welcome')
+    .map(d => `  <url><loc>${BASE_URL}/${d.slug}</loc><lastmod>${d.updated || d.date || today}</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>`)
+    .join('\n');
+
+  fs.writeFileSync(SITEMAP,
+    `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+    `  <url><loc>${BASE_URL}/</loc><lastmod>${today}</lastmod><changefreq>weekly</changefreq><priority>1.0</priority></url>\n` +
+    urls + `\n</urlset>\n`
+  );
+
+  return {
+    ok:     errors.length === 0,
+    count:  manifest.length,
+    stdout: `Generated ${manifest.length} docs`,
+    stderr: errors.join('\n'),
+  };
+}
+
+// ─── Отправка полной перезагрузки клиенту ────────────────────────────────────
+
+function sendFullReload(server) {
+  try {
+    server.environments.client.hot.send({ type: 'full-reload', path: '*' });
+  } catch {
+    try { server.ws?.send({ type: 'full-reload', path: '*' }); } catch {}
+  }
+}
+
+// ─── Обработчики команд ───────────────────────────────────────────────────────
+
+async function handlePing() {
+  return { pong: true, ts: Date.now() };
+}
+
+async function handleWriteFile({ filePath, content }) {
+  const abs = assertSafe(filePath);
+  if (!canWrite(abs)) throw new Error(`Write not allowed: ${relPath(abs)}`);
+  await fs.promises.mkdir(path.dirname(abs), { recursive: true });
+  await fs.promises.writeFile(abs, content, 'utf-8');
+  return { written: relPath(abs) };
+}
+
+async function handleMkdir({ dirPath }) {
+  const abs = assertSafe(dirPath);
+  if (!canWrite(abs)) throw new Error(`Write not allowed: ${relPath(abs)}`);
+  await fs.promises.mkdir(abs, { recursive: true });
+  return { created: relPath(abs) };
+}
+
+async function handleReadFile({ filePath }) {
+  const abs = assertSafe(filePath);
+  if (!canRead(abs)) throw new Error(`Read not allowed: ${relPath(abs)}`);
+  // Если файл не существует — возвращаем пустую строку вместо ошибки
+  try {
+    return { content: await fs.promises.readFile(abs, 'utf-8') };
+  } catch (err) {
+    if (err.code === 'ENOENT') return { content: '' };
+    throw err;
+  }
+}
+
+async function handleDeleteFile({ filePath }) {
+  const abs = assertSafe(filePath);
+  if (!canWrite(abs)) throw new Error(`Delete not allowed: ${relPath(abs)}`);
+  await fs.promises.rm(abs, { recursive: true, force: true });
+  return { deleted: relPath(abs) };
+}
+
+async function handleListDocs() {
+  const result = [];
+  function scan(dir, depth = 0) {
+    if (!fs.existsSync(dir)) return;
+    for (const item of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (item.name.startsWith('.')) continue;
+      const full = path.join(dir, item.name);
+      const rel  = relPath(full);
+      if (item.isDirectory()) {
+        result.push({ type: 'dir', path: rel, name: item.name, depth });
+        scan(full, depth + 1);
+      } else if (item.name.endsWith('.md')) {
+        result.push({ type: 'file', path: rel, name: item.name, depth });
+      }
+    }
+  }
+  scan(DOCS_DIR);
+  return { entries: result };
+}
+
+async function handleReadContacts() {
+  return { content: await fs.promises.readFile(path.join(ROOT, 'src/shared/data/contacts.ts'), 'utf-8') };
+}
+
+async function handleWriteContacts({ content }) {
+  await fs.promises.writeFile(path.join(ROOT, 'src/shared/data/contacts.ts'), content, 'utf-8');
+  return { ok: true };
+}
+
+async function handleUploadAsset({ filename, base64 }) {
+  const dir = path.join(ROOT, 'public/assets');
+  await fs.promises.mkdir(dir, { recursive: true });
+  await fs.promises.writeFile(path.join(dir, filename), Buffer.from(base64, 'base64'));
+  return { path: `/assets/${filename}` };
+}
+
+async function handleUploadFavicon({ base64, mimeType }) {
+  const ext = imageExtFromMime(mimeType);
+  const rel = `/favicon.${ext}`;
+  await fs.promises.writeFile(path.join(ROOT, `public/favicon.${ext}`), Buffer.from(base64, 'base64'));
+  const config = normalizeSiteConfig(await readSiteConfigFile());
+  await writeSiteConfigFile({ ...config, favicon: rel });
+  return { path: rel };
+}
+
+async function handleUploadLogo({ variant, base64, mimeType }) {
+  if (!['light', 'dark'].includes(variant)) throw new Error('Unknown logo variant');
+  const ext = imageExtFromMime(mimeType);
+  const basename = variant === 'light' ? 'light_logo' : 'dark_logo';
+  const rel = `/${basename}.${ext}`;
+
+  await Promise.all(['png', 'svg', 'ico', 'webp'].map(oldExt =>
+    fs.promises.rm(path.join(ROOT, `public/${basename}.${oldExt}`), { force: true })
+  ));
+  await fs.promises.writeFile(path.join(ROOT, `public/${basename}.${ext}`), Buffer.from(base64, 'base64'));
+
+  const config = normalizeSiteConfig(await readSiteConfigFile());
+  await writeSiteConfigFile({
+    ...config,
+    [variant === 'light' ? 'lightLogo' : 'darkLogo']: rel,
+  });
+  return { path: rel };
+}
+
+async function handleRunGenerate() {
+  return runGenerate();
+}
+
+async function handleRenderPreview({ markdown }) {
+  try {
+    const utils = await loadUtils();
+    if (typeof utils.renderMarkdownToHtml === 'function') {
+      return { html: utils.renderMarkdownToHtml(markdown) };
+    }
+    if (typeof utils.buildDocFromPath === 'function') {
+      const tmp = path.join(DOCS_DIR, '.preview-tmp.md');
+      await fs.promises.mkdir(DOCS_DIR, { recursive: true });
+      await fs.promises.writeFile(tmp, markdown, 'utf-8');
+      try {
+        const doc = utils.buildDocFromPath(tmp, DOCS_DIR);
+        await fs.promises.unlink(tmp).catch(() => {});
+        return { html: doc.content ?? doc.html ?? doc.body ?? '' };
+      } catch (e) {
+        await fs.promises.unlink(tmp).catch(() => {});
+        return { html: '', error: `buildDocFromPath failed: ${e.message}` };
+      }
+    }
+    return { html: '', error: 'No render function found in docUtils.' };
+  } catch (err) {
+    return { html: '', error: err.message };
+  }
+}
+
+// ─── Обработчики site-config ──────────────────────────────────────────────────
+
+async function handleReadSiteConfig() {
+  return { config: normalizeSiteConfig(await readSiteConfigFile()) };
+}
+
+async function handleWriteSiteConfig({ config }) {
+  await writeSiteConfigFile(normalizeSiteConfig(config));
+  return { ok: true };
+}
+
+// ─── Таблица маршрутизации команд ─────────────────────────────────────────────
+
+export const HANDLERS = {
+  ping:            handlePing,
+  writeFile:       handleWriteFile,
+  mkdir:           handleMkdir,
+  readFile:        handleReadFile,
+  deleteFile:      handleDeleteFile,
+  listDocs:        handleListDocs,
+  readContacts:    handleReadContacts,
+  writeContacts:   handleWriteContacts,
+  uploadAsset:     handleUploadAsset,
+  uploadFavicon:   handleUploadFavicon,
+  uploadLogo:      handleUploadLogo,
+  runGenerate:     handleRunGenerate,
+  renderPreview:   handleRenderPreview,
+  readSiteConfig:  handleReadSiteConfig,
+  writeSiteConfig: handleWriteSiteConfig,
+};
+
+
+
+export const MUTATING = new Set(['writeFile', 'mkdir', 'deleteFile', 'moveEntry', 'renameEntry']);
+
+function assertSafe(filePath, base = ROOT) {
+  const resolved = path.resolve(path.isAbsolute(filePath) ? filePath : path.join(ROOT, filePath));
+  const root = path.resolve(base);
+  if (resolved !== root && !resolved.startsWith(root + path.sep)) throw new Error('Path traversal detected');
+  return resolved;
+}
+
+function readFrontmatterMeta(filePath) {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    if (!raw.startsWith('---\n')) return {};
+    const end = raw.indexOf('\n---\n', 4);
+    if (end === -1) return {};
+    const meta = {};
+    for (const line of raw.slice(4, end).split('\n')) {
+      const i = line.indexOf(':');
+      if (i > 0) meta[line.slice(0, i).trim()] = line.slice(i + 1).trim().replace(/^['"]|['"]$/g, '');
+    }
+    return meta;
+  } catch { return {}; }
+}
+
+function parseEntryName(name) {
+  const base = name.replace(/\.md$/, '');
+  const tm = /^\[([NCA])\]/.exec(base);
+  const type = tm?.[1] ?? null;
+  const rest = tm ? base.slice(tm[0].length) : base;
+  const im = /^\[([^\]]{1,60})\]/.exec(rest);
+  const icon = im?.[1] ?? null;
+  const titlePart = im ? rest.slice(im[0].length) : rest;
+  const sm = /^([^{}]{1,300})\{([^{}]{1,200})\}$/.exec(titlePart);
+  return { type, icon, title: (sm ? sm[1] : titlePart).trim(), slug: sm?.[2]?.trim() ?? null };
+}
+
+async function handleListCustomPages() {
+  const dir = path.join(ROOT, 'src/custom');
+  const pages = [];
+  async function scan(d) {
+    if (!fs.existsSync(d)) return;
+    for (const ent of await fs.promises.readdir(d, { withFileTypes: true })) {
+      if (ent.name.startsWith('.')) continue;
+      const full = path.join(d, ent.name);
+      if (ent.isDirectory()) await scan(full);
+      else if (/\.(astro|tsx|jsx|mdx?)$/.test(ent.name)) {
+        pages.push({ slug: relPath(full).replace(/^src\/custom\//, '').replace(/\.[^.]+$/, '').replace(/\/index$/, ''), folderName: path.basename(path.dirname(full)) });
+      }
+    }
+  }
+  await scan(dir);
+  return { pages };
+}
+
+async function handleReadNavStructure() {
+  function scan(dir, depth = 0) {
+    if (!fs.existsSync(dir)) return [];
+    return fs.readdirSync(dir, { withFileTypes: true }).filter(e => !e.name.startsWith('.')).map(ent => {
+      const full = path.join(dir, ent.name);
+      const node = { type: ent.isDirectory() ? 'dir' : 'file', path: relPath(full), name: ent.name, depth, parsed: parseEntryName(ent.name), meta: ent.isFile() ? readFrontmatterMeta(full) : {}, children: [] };
+      if (ent.isDirectory()) node.children = scan(full, depth + 1);
+      return node;
+    }).filter(n => n.type === 'dir' || n.name.endsWith('.md'));
+  }
+  return { tree: scan(DOCS_DIR) };
+}
+
+async function handleMoveEntry({ srcPath, dstPath }) {
+  const src = assertSafe(srcPath, DOCS_DIR);
+  const dstBase = assertSafe(dstPath, DOCS_DIR);
+  const dst = fs.existsSync(dstBase) && fs.statSync(dstBase).isDirectory() ? path.join(dstBase, path.basename(src)) : dstBase;
+  assertSafe(dst, DOCS_DIR);
+  await fs.promises.mkdir(path.dirname(dst), { recursive: true });
+  await fs.promises.rename(src, dst);
+  return { ok: true, path: relPath(dst) };
+}
+
+async function handleRenameEntry({ oldPath, newName }) {
+  if (newName.includes('/') || newName.includes('\\') || newName.includes('..')) throw new Error('Invalid name');
+  const oldAbs = assertSafe(oldPath, DOCS_DIR);
+  const nextAbs = assertSafe(path.join(path.dirname(oldAbs), newName), DOCS_DIR);
+  await fs.promises.rename(oldAbs, nextAbs);
+  return { ok: true, path: relPath(nextAbs) };
+}
+
+HANDLERS.listCustomPages = handleListCustomPages;
+HANDLERS.readNavStructure = handleReadNavStructure;
+HANDLERS.moveEntry = handleMoveEntry;
+HANDLERS.renameEntry = handleRenameEntry;
+

--- a/scripts/devBridge.mjs
+++ b/scripts/devBridge.mjs
@@ -1,330 +1,13 @@
 /**
- * Hub Dev Panel — WebSocket Bridge v4
+ * Hub Dev Panel — temporary WebSocket compatibility bridge.
  */
 
 import { WebSocketServer } from 'ws';
-import fs   from 'node:fs';
+import { HANDLERS, MUTATING, runGenerate, ROOT } from './bridgeHandlers.mjs';
 import path from 'node:path';
 
-const ROOT       = process.cwd();
-const DOCS_DIR   = path.join(ROOT, 'Docs');
-const OUTPUT_DIR = path.join(ROOT, 'public/data/docs');
-const MANIFEST   = path.join(OUTPUT_DIR, 'manifest.json');
-const SITEMAP    = path.join(ROOT, 'public/sitemap.xml');
-const SITE_CONFIG_PATH = path.join(ROOT, 'public/data/site-config.json');
-const BASE_URL   = 'https://opensophy.com';
-
-// IPv4-mapped IPv6-адрес для localhost (::ffff:127.0.0.1) — стандартное представление Node.js
 const LOCALHOST_IPV4_MAPPED = '::ffff:127.0.0.1';
-
-// Адреса локального хоста, которым разрешено подключение
 const LOCALHOST_IPS = new Set(['::1', '127.0.0.1', LOCALHOST_IPV4_MAPPED]);
-
-// ─── Разрешённые пути ─────────────────────────────────────────────────────────
-
-const ALLOWED_WRITE = [
-  'Docs/',
-  'src/shared/data/',
-  'src/app/layouts/',
-  'src/app/pages/',
-  'public/',
-];
-const ALLOWED_READ = [
-  ...ALLOWED_WRITE,
-  'src/shared/data/contacts.ts',
-  'src/shared/data/seo.ts',
-];
-
-function relPath(abs) {
-  return path.relative(ROOT, abs).replaceAll('\\', '/');
-}
-function canWrite(absPath) {
-  const rel = relPath(absPath);
-  return ALLOWED_WRITE.some(p => rel.startsWith(p));
-}
-function canRead(absPath) {
-  const rel = relPath(absPath);
-  return ALLOWED_READ.some(p => rel === p || rel.startsWith(p));
-}
-
-function imageExtFromMime(mimeType) {
-  if (mimeType === 'image/svg+xml') return 'svg';
-  if (mimeType === 'image/x-icon' || mimeType === 'image/vnd.microsoft.icon') return 'ico';
-  if (mimeType === 'image/webp') return 'webp';
-  return 'png';
-}
-
-async function readSiteConfigFile() {
-  try {
-    if (!fs.existsSync(SITE_CONFIG_PATH)) return {};
-    return JSON.parse(await fs.promises.readFile(SITE_CONFIG_PATH, 'utf-8'));
-  } catch {
-    return {};
-  }
-}
-
-async function writeSiteConfigFile(config) {
-  await fs.promises.mkdir(path.dirname(SITE_CONFIG_PATH), { recursive: true });
-  await fs.promises.writeFile(SITE_CONFIG_PATH, JSON.stringify(config, null, 2), 'utf-8');
-}
-
-function normalizeSiteConfig(config) {
-  return {
-    useLanding: config.useLanding === true,
-    showDotWaveBackground: config.showDotWaveBackground !== false,
-    favicon: typeof config.favicon === 'string' && config.favicon ? config.favicon : '/favicon.png',
-    lightLogo: typeof config.lightLogo === 'string' ? config.lightLogo : '',
-    darkLogo: typeof config.darkLogo === 'string' ? config.darkLogo : '',
-  };
-}
-
-// ─── Загрузка утилит ──────────────────────────────────────────────────────────
-
-let _utils = null;
-
-async function loadUtils() {
-  const url = `${pathToFileURL(path.join(ROOT, 'scripts/docUtils.mjs'))}?bust=${Date.now()}`;
-  _utils = await import(url);
-  return _utils;
-}
-
-function pathToFileURL(p) {
-  return 'file:///' + p.replaceAll('\\', '/').replace(/^\//, '');
-}
-
-// ─── Генерация манифеста и sitemap ────────────────────────────────────────────
-
-async function runGenerate() {
-  const { scanDocsDirectoryRecursive, buildDocFromPath } = await loadUtils();
-
-  if (!fs.existsSync(DOCS_DIR)) return { ok: false, stdout: '', stderr: 'Docs/ not found' };
-  fs.mkdirSync(OUTPUT_DIR, { recursive: true });
-
-  const allFiles = scanDocsDirectoryRecursive(DOCS_DIR);
-  const manifest = [];
-  const errors   = [];
-  const SKIP     = new Set(['content', 'keywords', 'robots']);
-
-  for (const mdPath of allFiles) {
-    try {
-      const doc   = buildDocFromPath(mdPath, DOCS_DIR);
-      const entry = Object.fromEntries(Object.entries(doc).filter(([k]) => !SKIP.has(k)));
-      manifest.push(entry);
-    } catch (err) {
-      errors.push(`${relPath(mdPath)}: ${err.message}`);
-    }
-  }
-
-  const sorted = [...manifest].sort((a, b) => {
-  const pa = a.priority ?? 999;
-  const pb = b.priority ?? 999;
-
-  if (pa !== pb) {
-    return pa - pb;
-  }
-
-  return new Date(b.date ?? 0).getTime() - new Date(a.date ?? 0).getTime();
-});
-
-  fs.writeFileSync(MANIFEST, JSON.stringify(sorted));
-
-  const today = new Date().toISOString().split('T')[0];
-  const urls = sorted
-    .filter(d => d.slug && d.slug !== 'welcome')
-    .map(d => `  <url><loc>${BASE_URL}/${d.slug}</loc><lastmod>${d.updated || d.date || today}</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>`)
-    .join('\n');
-
-  fs.writeFileSync(SITEMAP,
-    `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
-    `  <url><loc>${BASE_URL}/</loc><lastmod>${today}</lastmod><changefreq>weekly</changefreq><priority>1.0</priority></url>\n` +
-    urls + `\n</urlset>\n`
-  );
-
-  return {
-    ok:     errors.length === 0,
-    count:  manifest.length,
-    stdout: `Generated ${manifest.length} docs`,
-    stderr: errors.join('\n'),
-  };
-}
-
-// ─── Отправка полной перезагрузки клиенту ────────────────────────────────────
-
-function sendFullReload(server) {
-  try {
-    server.environments.client.hot.send({ type: 'full-reload', path: '*' });
-  } catch {
-    try { server.ws?.send({ type: 'full-reload', path: '*' }); } catch {}
-  }
-}
-
-// ─── Обработчики команд ───────────────────────────────────────────────────────
-
-async function handlePing() {
-  return { pong: true, ts: Date.now() };
-}
-
-async function handleWriteFile({ filePath, content }) {
-  const abs = path.isAbsolute(filePath) ? filePath : path.join(ROOT, filePath);
-  if (!canWrite(abs)) throw new Error(`Write not allowed: ${relPath(abs)}`);
-  await fs.promises.mkdir(path.dirname(abs), { recursive: true });
-  await fs.promises.writeFile(abs, content, 'utf-8');
-  return { written: relPath(abs) };
-}
-
-async function handleMkdir({ dirPath }) {
-  const abs = path.isAbsolute(dirPath) ? dirPath : path.join(ROOT, dirPath);
-  if (!canWrite(abs)) throw new Error(`Write not allowed: ${relPath(abs)}`);
-  await fs.promises.mkdir(abs, { recursive: true });
-  return { created: relPath(abs) };
-}
-
-async function handleReadFile({ filePath }) {
-  const abs = path.isAbsolute(filePath) ? filePath : path.join(ROOT, filePath);
-  if (!canRead(abs)) throw new Error(`Read not allowed: ${relPath(abs)}`);
-  // Если файл не существует — возвращаем пустую строку вместо ошибки
-  try {
-    return { content: await fs.promises.readFile(abs, 'utf-8') };
-  } catch (err) {
-    if (err.code === 'ENOENT') return { content: '' };
-    throw err;
-  }
-}
-
-async function handleDeleteFile({ filePath }) {
-  const abs = path.isAbsolute(filePath) ? filePath : path.join(ROOT, filePath);
-  if (!canWrite(abs)) throw new Error(`Delete not allowed: ${relPath(abs)}`);
-  await fs.promises.rm(abs, { recursive: true, force: true });
-  return { deleted: relPath(abs) };
-}
-
-async function handleListDocs() {
-  const result = [];
-  function scan(dir, depth = 0) {
-    if (!fs.existsSync(dir)) return;
-    for (const item of fs.readdirSync(dir, { withFileTypes: true })) {
-      if (item.name.startsWith('.')) continue;
-      const full = path.join(dir, item.name);
-      const rel  = relPath(full);
-      if (item.isDirectory()) {
-        result.push({ type: 'dir', path: rel, name: item.name, depth });
-        scan(full, depth + 1);
-      } else if (item.name.endsWith('.md')) {
-        result.push({ type: 'file', path: rel, name: item.name, depth });
-      }
-    }
-  }
-  scan(DOCS_DIR);
-  return { entries: result };
-}
-
-async function handleReadContacts() {
-  return { content: await fs.promises.readFile(path.join(ROOT, 'src/shared/data/contacts.ts'), 'utf-8') };
-}
-
-async function handleWriteContacts({ content }) {
-  await fs.promises.writeFile(path.join(ROOT, 'src/shared/data/contacts.ts'), content, 'utf-8');
-  return { ok: true };
-}
-
-async function handleUploadAsset({ filename, base64 }) {
-  const dir = path.join(ROOT, 'public/assets');
-  await fs.promises.mkdir(dir, { recursive: true });
-  await fs.promises.writeFile(path.join(dir, filename), Buffer.from(base64, 'base64'));
-  return { path: `/assets/${filename}` };
-}
-
-async function handleUploadFavicon({ base64, mimeType }) {
-  const ext = imageExtFromMime(mimeType);
-  const rel = `/favicon.${ext}`;
-  await fs.promises.writeFile(path.join(ROOT, `public/favicon.${ext}`), Buffer.from(base64, 'base64'));
-  const config = normalizeSiteConfig(await readSiteConfigFile());
-  await writeSiteConfigFile({ ...config, favicon: rel });
-  return { path: rel };
-}
-
-async function handleUploadLogo({ variant, base64, mimeType }) {
-  if (!['light', 'dark'].includes(variant)) throw new Error('Unknown logo variant');
-  const ext = imageExtFromMime(mimeType);
-  const basename = variant === 'light' ? 'light_logo' : 'dark_logo';
-  const rel = `/${basename}.${ext}`;
-
-  await Promise.all(['png', 'svg', 'ico', 'webp'].map(oldExt =>
-    fs.promises.rm(path.join(ROOT, `public/${basename}.${oldExt}`), { force: true })
-  ));
-  await fs.promises.writeFile(path.join(ROOT, `public/${basename}.${ext}`), Buffer.from(base64, 'base64'));
-
-  const config = normalizeSiteConfig(await readSiteConfigFile());
-  await writeSiteConfigFile({
-    ...config,
-    [variant === 'light' ? 'lightLogo' : 'darkLogo']: rel,
-  });
-  return { path: rel };
-}
-
-async function handleRunGenerate() {
-  return runGenerate();
-}
-
-async function handleRenderPreview({ markdown }) {
-  try {
-    const utils = await loadUtils();
-    if (typeof utils.renderMarkdownToHtml === 'function') {
-      return { html: utils.renderMarkdownToHtml(markdown) };
-    }
-    if (typeof utils.buildDocFromPath === 'function') {
-      const tmp = path.join(DOCS_DIR, '.preview-tmp.md');
-      await fs.promises.mkdir(DOCS_DIR, { recursive: true });
-      await fs.promises.writeFile(tmp, markdown, 'utf-8');
-      try {
-        const doc = utils.buildDocFromPath(tmp, DOCS_DIR);
-        await fs.promises.unlink(tmp).catch(() => {});
-        return { html: doc.content ?? doc.html ?? doc.body ?? '' };
-      } catch (e) {
-        await fs.promises.unlink(tmp).catch(() => {});
-        return { html: '', error: `buildDocFromPath failed: ${e.message}` };
-      }
-    }
-    return { html: '', error: 'No render function found in docUtils.' };
-  } catch (err) {
-    return { html: '', error: err.message };
-  }
-}
-
-// ─── Обработчики site-config ──────────────────────────────────────────────────
-
-async function handleReadSiteConfig() {
-  return { config: normalizeSiteConfig(await readSiteConfigFile()) };
-}
-
-async function handleWriteSiteConfig({ config }) {
-  await writeSiteConfigFile(normalizeSiteConfig(config));
-  return { ok: true };
-}
-
-// ─── Таблица маршрутизации команд ─────────────────────────────────────────────
-
-const HANDLERS = {
-  ping:            handlePing,
-  writeFile:       handleWriteFile,
-  mkdir:           handleMkdir,
-  readFile:        handleReadFile,
-  deleteFile:      handleDeleteFile,
-  listDocs:        handleListDocs,
-  readContacts:    handleReadContacts,
-  writeContacts:   handleWriteContacts,
-  uploadAsset:     handleUploadAsset,
-  uploadFavicon:   handleUploadFavicon,
-  uploadLogo:      handleUploadLogo,
-  runGenerate:     handleRunGenerate,
-  renderPreview:   handleRenderPreview,
-  readSiteConfig:  handleReadSiteConfig,
-  writeSiteConfig: handleWriteSiteConfig,
-};
-
-const MUTATING = new Set(['writeFile', 'mkdir', 'deleteFile', 'runGenerate']);
-
-// ─── Astro интеграция ─────────────────────────────────────────────────────────
 
 export function devBridgeIntegration() {
   return {
@@ -332,94 +15,79 @@ export function devBridgeIntegration() {
     hooks: {
       'astro:server:setup': ({ server, logger }) => {
         let suppressReloadUntil = 0;
-
         try {
           const unwatch = () => {
             try { server.watcher.unwatch(path.join(ROOT, 'Docs')); } catch {}
             try { server.watcher.unwatch(path.join(ROOT, 'src/shared/data')); } catch {}
           };
-          unwatch();
-          setTimeout(unwatch, 300);
-          setTimeout(unwatch, 1000);
-        } catch (e) {
-          logger.warn('[hub-dev] Could not unwatch dirs: ' + e.message);
-        }
+          unwatch(); setTimeout(unwatch, 300); setTimeout(unwatch, 1000);
+        } catch (e) { logger.warn('[hub-dev] Could not unwatch dirs: ' + e.message); }
 
         try {
           const hotObj = server.hot ?? server.ws;
           if (hotObj && typeof hotObj.send === 'function') {
-            const _origSend = hotObj.send.bind(hotObj);
+            const orig = hotObj.send.bind(hotObj);
             hotObj.send = (payload, ...rest) => {
-              if (payload?.type === 'full-reload' && Date.now() < suppressReloadUntil) {
-                logger.info('[hub-dev] Suppressed full-reload (bridge write in progress)');
-                return;
-              }
-              return _origSend(payload, ...rest);
+              if (payload?.type === 'full-reload' && Date.now() < suppressReloadUntil) return;
+              return orig(payload, ...rest);
             };
           }
-        } catch (e) {
-          logger.warn('[hub-dev] Could not intercept hot.send: ' + e.message);
-        }
-
+        } catch {}
         const suppressReload = () => { suppressReloadUntil = Date.now() + 2000; };
 
-        const wss = new WebSocketServer({ port: 7777, host: '127.0.0.1' });
-        logger.info('[hub-dev] Bridge ready → ws://127.0.0.1:7777 | Press Ctrl+Shift+D in browser');
 
-        wss.on('connection', (ws, req) => {
-          const ip = req.socket.remoteAddress ?? '';
-          if (!LOCALHOST_IPS.has(ip)) {
-            logger.warn(`[hub-dev] Rejected from ${ip}`);
-            ws.close(1008, 'Forbidden');
+        const sseClients = new Set();
+        const allowedHosts = () => (process.env.BRIDGE_ALLOWED_HOSTS ?? 'localhost,127.0.0.1').split(',').map(x => x.trim()).filter(Boolean);
+        const writeSse = (res, event, data = {}) => res.write(`event: ${event}
+data: ${JSON.stringify(data)}
+
+`);
+        server.middlewares.use('/api/bridge', async (req, res, next) => {
+          const host = (req.headers.host ?? '').split(':')[0];
+          if (!allowedHosts().includes(host)) { res.statusCode = 404; res.end('Not Found'); return; }
+          if (req.method === 'GET' && req.url?.startsWith('/stream')) {
+            res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', Connection: 'keep-alive', 'X-Accel-Buffering': 'no' });
+            sseClients.add(res); writeSse(res, 'ping');
+            const timer = setInterval(() => writeSse(res, 'ping'), 20_000);
+            req.on('close', () => { clearInterval(timer); sseClients.delete(res); });
             return;
           }
-
-          logger.info(`[hub-dev] Client connected from ${ip}`);
-
-          ws.on('message', async raw => {
-            let msg;
-            try { msg = JSON.parse(raw.toString()); }
-            catch {
-              ws.send(JSON.stringify({ id: null, ok: false, error: 'Invalid JSON' }));
-              return;
-            }
-
+          if (req.method === 'POST' && req.url?.startsWith('/cmd')) {
+            let raw = '';
+            for await (const chunk of req) raw += chunk;
+            let msg; try { msg = JSON.parse(raw || '{}'); } catch { res.statusCode = 400; res.end(JSON.stringify({ id: null, ok: false, error: 'Invalid JSON' })); return; }
             const { id, action, payload } = msg;
             const handler = HANDLERS[action];
+            res.setHeader('Content-Type', 'application/json');
+            if (!handler) { res.statusCode = 400; res.end(JSON.stringify({ id, ok: false, error: `Unknown action: ${action}` })); return; }
+            try {
+              const result = await handler(payload ?? {});
+              if (MUTATING.has(action)) { suppressReload(); await runGenerate(); for (const client of sseClients) writeSse(client, 'reload'); }
+              res.end(JSON.stringify({ id, ok: true, result }));
+            } catch (err) { res.statusCode = 500; res.end(JSON.stringify({ id, ok: false, error: err.message })); }
+            return;
+          }
+          next();
+        });
 
-            if (!handler) {
-              ws.send(JSON.stringify({ id, ok: false, error: `Unknown action: ${action}` }));
-              return;
-            }
-
+        const wss = new WebSocketServer({ port: 7777, host: '127.0.0.1' });
+        logger.info('[hub-dev] Bridge fallback ready → ws://127.0.0.1:7777');
+        wss.on('connection', (ws, req) => {
+          const ip = req.socket.remoteAddress ?? '';
+          if (!LOCALHOST_IPS.has(ip)) { ws.close(1008, 'Forbidden'); return; }
+          ws.on('message', async raw => {
+            let msg; try { msg = JSON.parse(raw.toString()); } catch { ws.send(JSON.stringify({ id: null, ok: false, error: 'Invalid JSON' })); return; }
+            const { id, action, payload } = msg;
+            const handler = HANDLERS[action];
+            if (!handler) { ws.send(JSON.stringify({ id, ok: false, error: `Unknown action: ${action}` })); return; }
             try {
               const result = await handler(payload ?? {});
               ws.send(JSON.stringify({ id, ok: true, result }));
-
-              if (MUTATING.has(action)) {
-                suppressReload();
-                try {
-                  const gen = await runGenerate();
-                  logger.info(`[hub-dev] Regenerated (${gen.count} docs) after ${action}`);
-                  if (gen.stderr) logger.warn(`[hub-dev] Generate warnings: ${gen.stderr}`);
-                } catch (err) {
-                  logger.error(`[hub-dev] Generate failed: ${err.message}`);
-                }
-              }
-            } catch (err) {
-              logger.error(`[hub-dev] ${action} error: ${err.message}`);
-              ws.send(JSON.stringify({ id, ok: false, error: err.message }));
-            }
+              if (MUTATING.has(action)) { suppressReload(); await runGenerate(); }
+            } catch (err) { ws.send(JSON.stringify({ id, ok: false, error: err.message })); }
           });
-
-          ws.on('close', () => logger.info('[hub-dev] Client disconnected'));
-          ws.on('error', err => logger.error(`[hub-dev] WS error: ${err.message}`));
         });
-
-        server.httpServer?.on('close', () => {
-          wss.close();
-          logger.info('[hub-dev] Bridge closed');
-        });
+        server.httpServer?.on('close', () => wss.close());
       },
     },
   };

--- a/src/app/middleware.ts
+++ b/src/app/middleware.ts
@@ -1,0 +1,1 @@
+export { onRequest } from '../middleware/devBridge';

--- a/src/features/dev-panel/DevPanel.tsx
+++ b/src/features/dev-panel/DevPanel.tsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect, useRef, Suspense, lazy } from 'react';
 import { createPortal } from 'react-dom';
-import { useDevBridge } from './useDevBridge';
+import { reconnectBridge, useDevBridge } from './useDevBridge';
+import { toast } from './components/toastBus';
 import { ToastContainer } from './components/Toast';
-import { FileText, Users, Image, X, UserCog, WifiOff, Loader2, AlertCircle, Globe } from 'lucide-react';
+import { FileText, Users, Image, X, UserCog, WifiOff, Loader2, AlertCircle, Globe, Map } from 'lucide-react';
 import { ThemeTokensContext, makeT, type TTokens, useIsDark } from './theme';
 
+const NavPanel      = lazy(() => import('./panels/NavPanel'));
 const DocsPanel     = lazy(() => import('./panels/DocsPanel'));
 const ContactsPanel = lazy(() => import('./panels/ContactsPanel'));
 const AssetsPanel   = lazy(() => import('./panels/AssetsPanel'));
@@ -13,6 +15,7 @@ const SitePanel     = lazy(() => import('./panels/SitePanel'));
 // ─── Табы ────────────────────────────────────────────────────────────────────
 
 const TABS = [
+  { id: 'nav',      label: 'Навигация', icon: <Map size={13}/>      },
   { id: 'docs',     label: 'Страницы',  icon: <FileText size={13}/> },
   { id: 'contacts', label: 'Контакты',  icon: <Users size={13}/>    },
   { id: 'assets',   label: 'Ассеты',    icon: <Image size={13}/>    },
@@ -61,12 +64,14 @@ function clampRect(r: PanelRect): PanelRect {
 function statusColor(status: string, success: string, warning: string, danger: string): string {
   if (status === 'connected')  return success;
   if (status === 'connecting') return warning;
+  if (status === 'error') return warning;
   return danger;
 }
 
 function statusLabel(status: string): string {
   if (status === 'connected')  return 'Подключено';
   if (status === 'connecting') return 'Подключение...';
+  if (status === 'error') return 'Ошибка';
   return 'Отключено';
 }
 
@@ -109,7 +114,7 @@ export default function DevPanel() {
   const t          = React.useMemo(() => makeT(isDark), [isDark]);
 
   const [open, setOpen] = useState(false);
-  const [tab,  setTab]  = useState('docs');
+  const [tab,  setTab]  = useState('nav');
   const [rect, setRect] = useState<PanelRect>({ x: 16, y: 40, w: 520, h: 600 });
 
   const interacting = useRef<InteractMode>(null);
@@ -174,6 +179,17 @@ export default function DevPanel() {
       globalThis.removeEventListener('mousemove', onMove);
       globalThis.removeEventListener('mouseup',   onUp);
     };
+  }, []);
+
+
+  useEffect(() => {
+    const onStatus = (event: Event) => {
+      const detail = (event as CustomEvent<{ status: string; previous: string }>).detail;
+      if (detail.status === 'disconnected' && detail.previous === 'connected') toast.warning('Соединение прервано, переподключение...');
+      if (detail.status === 'connected' && detail.previous && detail.previous !== 'connected') toast.success('Соединение восстановлено');
+    };
+    globalThis.addEventListener('hub:bridge-status', onStatus);
+    return () => globalThis.removeEventListener('hub:bridge-status', onStatus);
   }, []);
 
   useEffect(() => {
@@ -397,14 +413,14 @@ export default function DevPanel() {
                     <WifiOff size={22} style={{ color: t.danger }}/>
                     <div style={{ fontSize: 12, color: t.fgMuted }}>Нет соединения. Запусти `astro dev`</div>
                     <button
-                      onClick={() => globalThis.location.reload()}
+                      onClick={() => reconnectBridge()}
                       style={{
                         padding: '6px 14px', borderRadius: 7, cursor: 'pointer',
                         border: `1px solid ${t.border}`, background: t.surfaceHov,
                         color: t.fg, fontSize: 11, fontFamily: t.mono,
                       }}
                     >
-                      Обновить
+Переподключить
                     </button>
                   </>
                 )}
@@ -416,6 +432,7 @@ export default function DevPanel() {
                 <Loader2 size={14} style={{ animation: 'devSpin 1s linear infinite' }}/> Загрузка...
               </div>
             }>
+              {tab === 'nav'      && <NavPanel/>}
               {tab === 'docs'     && <DocsPanel/>}
               {tab === 'contacts' && <ContactsPanel/>}
               {tab === 'assets'   && <AssetsPanel/>}

--- a/src/features/dev-panel/panels/DocsPanel.tsx
+++ b/src/features/dev-panel/panels/DocsPanel.tsx
@@ -13,7 +13,7 @@ import {
   Loader2, Bold, Italic, Code, Link, Hash, List,
   RefreshCw, Minus, Image, BarChart2, Table, Search,
   Columns, AlertCircle, Calculator, Footprints, LayoutGrid, Type,
-  Edit3,
+  Edit3, Eye,
 } from 'lucide-react';
 
 interface FlatEntry { type: 'file' | 'dir'; path: string; name: string; depth: number; }
@@ -645,14 +645,41 @@ function MarkdownEditor({ filePath, onClose, t }: { readonly filePath: string; r
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
   const [fmOpen, setFmOpen] = useState(false);
+  const [splitMode, setSplitModeState] = useState<'editor' | 'split' | 'preview'>(() => {
+    if (typeof sessionStorage === 'undefined') return 'editor';
+    const saved = sessionStorage.getItem('hub:editor:splitMode');
+    return saved === 'split' || saved === 'preview' || saved === 'editor' ? saved : 'editor';
+  });
+  const [previewHtml, setPreviewHtml] = useState('');
   const taRef = useRef<HTMLTextAreaElement>(null);
   const fmRef = useRef(fm);
   const bodyRef = useRef(body);
   useEffect(() => { fmRef.current = fm; }, [fm]);
   useEffect(() => { bodyRef.current = body; }, [body]);
 
+  const setSplitMode = (mode: 'editor' | 'split' | 'preview') => {
+    setSplitModeState(mode);
+    try { sessionStorage.setItem('hub:editor:splitMode', mode); } catch { /* noop */ }
+  };
+
+  useEffect(() => {
+    if (splitMode === 'editor') return;
+    if (previewTimer.current) clearTimeout(previewTimer.current);
+    previewTimer.current = setTimeout(async () => {
+      try {
+        const result = await bridge.renderPreview(bodyRef.current);
+        setPreviewHtml(result.html ?? '');
+      } catch (e) {
+        setPreviewHtml(`<p>${(e as Error).message}</p>`);
+      }
+    }, 400);
+    return () => { if (previewTimer.current) clearTimeout(previewTimer.current); };
+  }, [body, splitMode]);
+
+
   const bcRef = useRef<BroadcastChannel | null>(null);
   const liveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const previewTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (typeof BroadcastChannel !== 'undefined') {
@@ -843,26 +870,37 @@ function MarkdownEditor({ filePath, onClose, t }: { readonly filePath: string; r
         <div style={{ width: 1, height: 14, background: t.border, margin: '0 3px' }} />
         <BlockPicker onInsert={insertAtCursor} t={t} />
         <div style={{ flex: 1 }} />
+        {toolBtn(() => setSplitMode('editor'), <Edit3 size={11} />, 'Только редактор')}
+        {toolBtn(() => setSplitMode('split'), <Columns size={11} />, 'Редактор и превью')}
+        {toolBtn(() => setSplitMode('preview'), <Eye size={11} />, 'Только превью')}
         <span style={{ fontSize: 12, color: t.fgSub }}>{body.trim().split(/\s+/).filter(Boolean).length} слов</span>
       </div>
 
-      <textarea
-        ref={taRef}
-        value={body}
-        onChange={e => handleChange(e.target.value)}
-        onKeyDown={handleTab}
-        spellCheck={false}
-        placeholder="Начните писать..."
-        style={{
-          flex: 1, padding: '12px 14px', border: 'none',
-          background: t.inpBg,
-          color: t.editorFg,
-          fontSize: 12,
-          fontFamily: 'ui-monospace, "Cascadia Code", "Fira Code", monospace',
-          lineHeight: 1.75, resize: 'none', outline: 'none',
-          scrollbarWidth: 'thin', width: '100%', boxSizing: 'border-box',
-        } as React.CSSProperties}
-      />
+      <div style={{ flex: 1, minHeight: 0, display: 'flex', overflow: 'hidden' }}>
+        {splitMode !== 'preview' && (
+          <textarea
+            ref={taRef}
+            value={body}
+            onChange={e => handleChange(e.target.value)}
+            onKeyDown={handleTab}
+            spellCheck={false}
+            placeholder="Начните писать..."
+            style={{
+              flex: 1, padding: '12px 14px', border: 'none',
+              borderRight: splitMode === 'split' ? `1px solid ${t.border}` : 'none',
+              background: t.inpBg,
+              color: t.editorFg,
+              fontSize: 12,
+              fontFamily: 'ui-monospace, "Cascadia Code", "Fira Code", monospace',
+              lineHeight: 1.75, resize: 'none', outline: 'none',
+              scrollbarWidth: 'thin', width: '100%', boxSizing: 'border-box',
+            } as React.CSSProperties}
+          />
+        )}
+        {splitMode !== 'editor' && (
+          <div className="prose dark:prose-invert adm-scroll" style={{ flex: 1, overflowY: 'auto', padding: '12px 16px', background: t.inpBg, color: t.fg, fontSize: 13, lineHeight: 1.7 }} dangerouslySetInnerHTML={{ __html: previewHtml }} />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/features/dev-panel/panels/NavPanel.tsx
+++ b/src/features/dev-panel/panels/NavPanel.tsx
@@ -1,0 +1,81 @@
+import React, { useCallback, useContext, useEffect, useState } from 'react';
+import { Map, FolderPlus, FilePlus, Plus, RefreshCw, Trash2, Edit3, GripVertical, ChevronDown, ChevronRight } from 'lucide-react';
+import { bridge } from '../useDevBridge';
+import { toast } from '../components/toastBus';
+import { ThemeTokensContext } from '../theme';
+import type { TTokens } from '../theme';
+
+type Parsed = { type: 'N' | 'C' | 'A' | null; icon: string | null; title: string; slug: string | null };
+type NavEntry = { type: 'file' | 'dir'; path: string; name: string; depth: number; parsed: Parsed; meta?: Record<string, string>; children: NavEntry[] };
+type EntryKind = 'N' | 'C' | 'A';
+
+const toSlug = (s: string) => s.toLowerCase().trim().replace(/[^\p{L}\p{N}]+/gu, '-').replace(/^-+|-+$/g, '') || 'new-entry';
+const fileNameFor = (kind: EntryKind, title: string, slug: string, icon: string) => `${kind === 'A' ? '[A]' : `[${kind}][${icon || 'folder'}]`}${title}{${slug || toSlug(title)}}${kind === 'A' ? '.md' : ''}`;
+const join = (a: string, b: string) => `${a.replace(/\/$/, '')}/${b}`;
+
+function DragHandle() { return <GripVertical size={12} style={{ opacity: 0.55 }} />; }
+
+function CreateEntryModal({ parentPath, kind, existing, onClose, onDone, t }: { parentPath: string; kind: EntryKind; existing?: NavEntry; onClose: () => void; onDone: () => void; t: TTokens }) {
+  const [title, setTitle] = useState(existing?.parsed.title || 'Новая страница');
+  const [slug, setSlug] = useState(existing?.parsed.slug || toSlug(existing?.parsed.title || 'Новая страница'));
+  const [icon, setIcon] = useState(existing?.parsed.icon || (kind === 'A' ? '' : 'folder'));
+  const save = async () => {
+    const name = fileNameFor(kind, title, slug, icon);
+    try {
+      if (existing) await bridge.renameEntry(existing.path, name);
+      else if (kind === 'A') await bridge.writeFile(join(parentPath, name), `---\ntitle: ${title}\ndate: ${new Date().toISOString().split('T')[0]}\nrobots: index, follow\n---\n\n# ${title}\n`);
+      else await bridge.mkdir(join(parentPath, name));
+      toast.success(existing ? 'Переименовано' : 'Создано');
+      onDone(); onClose();
+    } catch (e) { toast.error((e as Error).message); }
+  };
+  return <div style={{ position: 'absolute', inset: 0, zIndex: 20, background: 'rgba(0,0,0,.35)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+    <div style={{ width: 360, border: `1px solid ${t.borderStrong}`, borderRadius: 12, background: t.bg, boxShadow: t.shadow, padding: 14 }}>
+      <h3 style={{ margin: '0 0 12px', fontSize: 14, color: t.fg }}>{existing ? 'Редактировать' : 'Создать'} {kind === 'N' ? 'секцию' : kind === 'C' ? 'категорию' : 'страницу'}</h3>
+      {[['Название', title, setTitle], ['Slug', slug, setSlug], ['Иконка', icon, setIcon] as const].map(([label, value, setter]) => kind === 'A' && label === 'Иконка' ? null : <label key={label} style={{ display: 'block', marginBottom: 8, fontSize: 11, color: t.fgSub }}>{label}<input value={value} onChange={e => setter(e.target.value)} style={{ width: '100%', marginTop: 3, boxSizing: 'border-box', padding: '7px 9px', borderRadius: 7, border: `1px solid ${t.border}`, background: t.inpBg, color: t.fg, fontFamily: t.mono }} /></label>)}
+      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 12 }}><button onClick={onClose}>Отмена</button><button onClick={save}>Сохранить</button></div>
+    </div>
+  </div>;
+}
+
+function NavNode({ node, onReload, onCreate, onEdit, t }: { node: NavEntry; onReload: () => void; onCreate: (parentPath: string, kind: EntryKind) => void; onEdit: (n: NavEntry) => void; t: TTokens }) {
+  const [open, setOpen] = useState(node.depth < 2);
+  const [over, setOver] = useState(false);
+  const isDir = node.type === 'dir';
+  const move = async (src: string) => { if (!src || src === node.path) return; try { await bridge.moveEntry(src, isDir ? node.path : node.path.split('/').slice(0, -1).join('/')); toast.success('Перемещено'); onReload(); } catch (e) { toast.error((e as Error).message); } };
+  return <div>
+    <div draggable onDragStart={e => e.dataTransfer.setData('text/plain', node.path)} onDragOver={e => { e.preventDefault(); setOver(true); }} onDragLeave={() => setOver(false)} onDrop={e => { e.preventDefault(); setOver(false); move(e.dataTransfer.getData('text/plain')); }}
+      title={`URL: /${node.parsed.slug || node.name.replace(/\.md$/, '')}`}
+      style={{ display: 'flex', alignItems: 'center', gap: 7, margin: '2px 6px', padding: `7px 8px 7px ${8 + node.depth * 14}px`, borderRadius: 8, background: over ? 'rgba(20,184,166,.14)' : t.surface, border: `1px solid ${over ? t.borderStrong : t.border}` }}>
+      <DragHandle />
+      <button onClick={() => setOpen(v => !v)} style={{ border: 0, background: 'transparent', color: t.fgSub }}>{isDir ? (open ? <ChevronDown size={12}/> : <ChevronRight size={12}/>) : null}</button>
+      <span style={{ flex: 1, color: t.fg, fontSize: 12 }}>{node.parsed.icon ? `${node.parsed.icon} ` : ''}{node.parsed.title || node.name} <small style={{ color: t.fgSub }}>[{node.parsed.type || (isDir ? 'C' : 'A')}]</small></span>
+      {isDir && node.parsed.type === 'N' && <button onClick={() => onCreate(node.path, 'C')} title="+ Категория"><FolderPlus size={13}/></button>}
+      {isDir && <button onClick={() => onCreate(node.path, 'A')} title="+ Страница"><FilePlus size={13}/></button>}
+      <button onClick={() => onEdit(node)} title="Редактировать"><Edit3 size={13}/></button>
+      <button onClick={async () => { if (confirm(`Удалить ${node.name}?`)) { await bridge.deleteFile(node.path); onReload(); } }} title="Удалить"><Trash2 size={13}/></button>
+    </div>
+    {isDir && open && node.children.map(c => <NavNode key={c.path} node={c} onReload={onReload} onCreate={onCreate} onEdit={onEdit} t={t} />)}
+  </div>;
+}
+
+function NavTree(props: { tree: NavEntry[]; onReload: () => void; onCreate: (parentPath: string, kind: EntryKind) => void; onEdit: (n: NavEntry) => void; t: TTokens }) {
+  return <>{props.tree.map(n => <NavNode key={n.path} node={n} onReload={props.onReload} onCreate={props.onCreate} onEdit={props.onEdit} t={props.t} />)}</>;
+}
+
+export default function NavPanel() {
+  const t = useContext(ThemeTokensContext);
+  const [tree, setTree] = useState<NavEntry[]>([]);
+  const [modal, setModal] = useState<{ parentPath: string; kind: EntryKind; existing?: NavEntry } | null>(null);
+  const load = useCallback(async () => { try { const r = await bridge.readNavStructure(); setTree(r.tree as NavEntry[]); } catch (e) { toast.error((e as Error).message); } }, []);
+  useEffect(() => { load(); }, [load]);
+  return <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', background: t.bg, position: 'relative' }}>
+    <div style={{ display: 'flex', gap: 8, alignItems: 'center', padding: 10, borderBottom: `1px solid ${t.border}`, background: t.surface }}>
+      <Map size={14}/><strong style={{ color: t.fg, fontSize: 12, flex: 1 }}>Навигация Docs/</strong>
+      <button onClick={() => setModal({ parentPath: 'Docs', kind: 'N' })}><Plus size={13}/> Секция</button>
+      <button onClick={load}><RefreshCw size={13}/></button>
+    </div>
+    <div className="adm-scroll" style={{ flex: 1, overflow: 'auto', padding: '8px 4px' }}><NavTree tree={tree} onReload={load} onCreate={(parentPath, kind) => setModal({ parentPath, kind })} onEdit={existing => setModal({ parentPath: existing.path.split('/').slice(0, -1).join('/'), kind: (existing.parsed.type || (existing.type === 'dir' ? 'C' : 'A')) as EntryKind, existing })} t={t} /></div>
+    {modal && <CreateEntryModal {...modal} onClose={() => setModal(null)} onDone={load} t={t} />}
+  </div>;
+}

--- a/src/features/dev-panel/useDevBridge.ts
+++ b/src/features/dev-panel/useDevBridge.ts
@@ -1,159 +1,98 @@
-/**
- * useDevBridge v2 — улучшенный WebSocket хук
- * - Экспоненциальный backoff для переподключения
- * - Типизированный API bridge
- * - Heartbeat для детекции обрыва
- */
-
 import { useEffect, useState } from 'react';
-
-const resolveWsUrl = (): string => {
-  if (!('location' in globalThis)) return 'ws://127.0.0.1:7777';
-  const proto = globalThis.location.protocol === 'https:' ? 'wss:' : 'ws:';
-  return `${proto}//${globalThis.location.hostname}:7777`;
-};
 
 export type BridgeStatus = 'connecting' | 'connected' | 'disconnected' | 'error';
 
-interface PendingMsg {
-  resolve: (v: unknown) => void;
-  reject: (e: Error) => void;
-  timeout: ReturnType<typeof setTimeout>;
-}
+interface BridgeResponse<T> { id?: string; ok?: boolean; result?: T; error?: string; }
+const BASE = '/api/bridge';
 
-interface BridgeResponse {
-  id?: string;
-  ok?: boolean;
-  result?: unknown;
-  error?: string;
-}
+class RequestQueue {
+  private queue: Array<() => Promise<void>> = [];
+  private running = false;
 
-// ─── Singleton connection manager ──────────────────────────────────────────────
-
-let ws: WebSocket | null = null;
-const pending     = new Map<string, PendingMsg>();
-const listeners   = new Set<(s: BridgeStatus) => void>();
-let status: BridgeStatus = 'disconnected';
-let reconnectDelay = 1000;
-let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
-let connectCalled  = false;
-
-function broadcast(s: BridgeStatus) {
-  status = s;
-  listeners.forEach(fn => fn(s));
-}
-
-function stopHeartbeat() {
-  if (heartbeatTimer) { clearInterval(heartbeatTimer); heartbeatTimer = null; }
-}
-
-function startHeartbeat() {
-  stopHeartbeat();
-  heartbeatTimer = setInterval(() => {
-    if (ws?.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ id: '__ping__', action: 'ping' }));
-    }
-  }, 15_000);
-}
-
-function connect() {
-  if (ws?.readyState === WebSocket.OPEN || ws?.readyState === WebSocket.CONNECTING) return;
-
-  broadcast('connecting');
-
-  try {
-    ws = new WebSocket(resolveWsUrl());
-  } catch {
-    broadcast('error');
-    scheduleReconnect();
-    return;
+  async add<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push(async () => {
+        try { resolve(await fn()); } catch (e) { reject(e); }
+      });
+      void this.drain();
+    });
   }
 
-  ws.onopen = () => {
-    reconnectDelay = 1000;
-    if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
-    broadcast('connected');
-    startHeartbeat();
-  };
+  private async drain() {
+    if (this.running) return;
+    this.running = true;
+    while (this.queue.length > 0) {
+      const job = this.queue.shift();
+      if (job) await job();
+    }
+    this.running = false;
+  }
+}
 
-  ws.onmessage = ev => {
-    let msg: BridgeResponse;
-    try { msg = JSON.parse(ev.data) as BridgeResponse; } catch { return; }
-    if (msg.id === '__ping__') return;
-    const p = pending.get(msg.id);
-    if (!p) return;
-    clearTimeout(p.timeout);
-    pending.delete(msg.id);
-    if (msg.ok) p.resolve(msg.result ?? null);
-    else p.reject(new Error(msg.error ?? 'Bridge error'));
-  };
+const queue = new RequestQueue();
+const listeners = new Set<(s: BridgeStatus) => void>();
+let currentStatus: BridgeStatus = 'disconnected';
+let es: EventSource | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let attempts = 0;
 
-  ws.onclose = () => {
-    stopHeartbeat();
-    pending.forEach(({ reject, timeout }) => { clearTimeout(timeout); reject(new Error('Disconnected')); });
-    pending.clear();
+function broadcast(s: BridgeStatus) {
+  const prev = currentStatus;
+  currentStatus = s;
+  listeners.forEach(fn => fn(s));
+  globalThis.dispatchEvent?.(new CustomEvent('hub:bridge-status', { detail: { status: s, previous: prev } }));
+}
+
+export function reconnectBridge() {
+  if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+  es?.close(); es = null; attempts = 0;
+  connectSSE();
+}
+
+function connectSSE() {
+  if (es || typeof EventSource === 'undefined') return;
+  broadcast('connecting');
+  es = new EventSource(`${BASE}/stream/`);
+  es.onopen = () => { attempts = 0; broadcast('connected'); };
+  es.onerror = () => {
+    es?.close(); es = null;
     broadcast('disconnected');
-    scheduleReconnect();
+    const delay = Math.min(1000 * 2 ** attempts, 30_000); attempts += 1;
+    reconnectTimer = setTimeout(connectSSE, delay);
   };
-
-  ws.onerror = () => {
-    broadcast('error');
-    if (ws?.readyState === WebSocket.OPEN || ws?.readyState === WebSocket.CONNECTING) {
-      ws.close();
-    }
-  };
+  es.addEventListener('ping', () => undefined);
+  es.addEventListener('reload', () => globalThis.dispatchEvent?.(new CustomEvent('hub:bridge-reload')));
 }
 
-function scheduleReconnect() {
-  if (reconnectTimer) return;
-  reconnectTimer = setTimeout(() => {
-    reconnectTimer = null;
-    reconnectDelay = Math.min(reconnectDelay * 1.5, 10_000);
-    connect();
-  }, reconnectDelay);
-}
-
-function send<T = unknown>(action: string, payload?: unknown): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    if (ws?.readyState !== WebSocket.OPEN) {
-      reject(new Error('Not connected'));
-      return;
+async function send<T>(action: string, payload?: unknown): Promise<T> {
+  return queue.add(async () => {
+    try {
+      const res = await fetch(`${BASE}/cmd/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action, payload, id: crypto.randomUUID() }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json() as BridgeResponse<T>;
+      if (!data.ok) throw new Error(data.error ?? 'Bridge error');
+      return data.result as T;
+    } catch (e) {
+      broadcast('error');
+      throw e;
     }
-    // crypto.randomUUID() используется для уникальной идентификации pending-запросов
-    const id = crypto.randomUUID();
-    const timeout = setTimeout(() => {
-      pending.delete(id);
-      reject(new Error(`Timeout: ${action}`));
-    }, 30_000);
-    pending.set(id, { resolve, reject, timeout });
-    ws.send(JSON.stringify({ id, action, payload }));
   });
 }
 
-// ─── Hook ─────────────────────────────────────────────────────────────────────
-
 export function useDevBridge() {
-  const [bridgeStatus, setBridgeStatus] = useState<BridgeStatus>(status);
-
+  const [status, setStatus] = useState<BridgeStatus>(currentStatus);
   useEffect(() => {
-    listeners.add(setBridgeStatus);
-    if (connectCalled) {
-      setBridgeStatus(status);
-    } else {
-      connectCalled = true;
-      connect();
-    }
-    return () => { listeners.delete(setBridgeStatus); };
+    listeners.add(setStatus);
+    setStatus(currentStatus);
+    connectSSE();
+    return () => { listeners.delete(setStatus); };
   }, []);
-
-  return {
-    status: bridgeStatus,
-    isConnected: bridgeStatus === 'connected',
-  };
+  return { status, isConnected: status === 'connected' };
 }
-
-// ─── Site config типы ─────────────────────────────────────────────────────────
 
 export interface SiteConfig {
   useLanding: boolean;
@@ -163,49 +102,23 @@ export interface SiteConfig {
   darkLogo?: string;
 }
 
-// ─── Typed bridge API ──────────────────────────────────────────────────────────
-
 export const bridge = {
-  writeFile: (filePath: string, content: string) =>
-    send<{ written: string }>('writeFile', { filePath, content }),
-
-  // Создаёт директорию без placeholder-файлов
-  mkdir: (dirPath: string) =>
-    send<{ created: string }>('mkdir', { dirPath }),
-
-  readFile: (filePath: string) =>
-    send<{ content: string }>('readFile', { filePath }),
-
-  deleteFile: (filePath: string) =>
-    send<{ deleted: string }>('deleteFile', { filePath }),
-
-  listDocs: () =>
-    send<{ entries: Array<{ type: 'file'|'dir'; path: string; name: string; depth: number }> }>('listDocs'),
-
-  readContacts: () =>
-    send<{ content: string }>('readContacts'),
-
-  writeContacts: (content: string) =>
-    send<{ ok: boolean }>('writeContacts', { content }),
-
-  uploadAsset: (filename: string, base64: string, mimeType: string) =>
-    send<{ path: string }>('uploadAsset', { filename, base64, mimeType }),
-
-  uploadFavicon: (base64: string, mimeType: string) =>
-    send<{ path: string }>('uploadFavicon', { base64, mimeType }),
-
-  uploadLogo: (variant: 'light' | 'dark', base64: string, mimeType: string) =>
-    send<{ path: string }>('uploadLogo', { variant, base64, mimeType }),
-
-  runGenerate: () =>
-    send<{ ok: boolean; stdout: string; stderr: string }>('runGenerate'),
-
-  renderPreview: (markdown: string) =>
-    send<{ html: string; error?: string }>('renderPreview', { markdown }),
-
-  readSiteConfig: () =>
-    send<{ config: SiteConfig }>('readSiteConfig'),
-
-  writeSiteConfig: (config: SiteConfig) =>
-    send<{ ok: boolean }>('writeSiteConfig', { config }),
+  writeFile: (filePath: string, content: string) => send<{ written: string }>('writeFile', { filePath, content }),
+  mkdir: (dirPath: string) => send<{ created: string }>('mkdir', { dirPath }),
+  readFile: (filePath: string) => send<{ content: string }>('readFile', { filePath }),
+  deleteFile: (filePath: string) => send<{ deleted: string }>('deleteFile', { filePath }),
+  listDocs: () => send<{ entries: Array<{ type: 'file'|'dir'; path: string; name: string; depth: number }> }>('listDocs'),
+  readContacts: () => send<{ content: string }>('readContacts'),
+  writeContacts: (content: string) => send<{ ok: boolean }>('writeContacts', { content }),
+  uploadAsset: (filename: string, base64: string, mimeType: string) => send<{ path: string }>('uploadAsset', { filename, base64, mimeType }),
+  uploadFavicon: (base64: string, mimeType: string) => send<{ path: string }>('uploadFavicon', { base64, mimeType }),
+  uploadLogo: (variant: 'light' | 'dark', base64: string, mimeType: string) => send<{ path: string }>('uploadLogo', { variant, base64, mimeType }),
+  runGenerate: () => send<{ ok: boolean; stdout: string; stderr: string }>('runGenerate'),
+  renderPreview: (markdown: string) => send<{ html: string; error?: string }>('renderPreview', { markdown }),
+  readSiteConfig: () => send<{ config: SiteConfig }>('readSiteConfig'),
+  writeSiteConfig: (config: SiteConfig) => send<{ ok: boolean }>('writeSiteConfig', { config }),
+  listCustomPages: () => send<{ pages: Array<{ slug: string; folderName: string }> }>('listCustomPages'),
+  readNavStructure: () => send<{ tree: unknown[] }>('readNavStructure'),
+  moveEntry: (srcPath: string, dstPath: string) => send<{ ok: boolean; path?: string }>('moveEntry', { srcPath, dstPath }),
+  renameEntry: (oldPath: string, newName: string) => send<{ ok: boolean; path?: string }>('renameEntry', { oldPath, newName }),
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,1 @@
+export { onRequest } from './middleware/devBridge';

--- a/src/middleware/devBridge.ts
+++ b/src/middleware/devBridge.ts
@@ -1,0 +1,87 @@
+import type { APIContext, MiddlewareNext } from 'astro';
+import { HANDLERS, MUTATING, runGenerate } from '../../scripts/bridgeHandlers.mjs';
+
+type BridgeController = ReadableStreamDefaultController<Uint8Array>;
+const encoder = new TextEncoder();
+const clients = new Set<BridgeController>();
+
+function sendEvent(controller: BridgeController, event: string, data: unknown = {}) {
+  controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+}
+
+function broadcast(event: string, data: unknown = {}) {
+  for (const controller of clients) {
+    try { sendEvent(controller, event, data); } catch { clients.delete(controller); }
+  }
+}
+
+function allowed(ctx: APIContext) {
+  const isDev = import.meta.env.DEV;
+  const hostname = new URL(ctx.request.url).hostname;
+  const allowedHosts = (process.env.BRIDGE_ALLOWED_HOSTS ?? 'localhost,127.0.0.1')
+    .split(',')
+    .map(v => v.trim())
+    .filter(Boolean);
+  return isDev && allowedHosts.includes(hostname);
+}
+
+export async function handleDevBridgeRequest(ctx: APIContext) {
+  const url = new URL(ctx.request.url);
+  const routePath = url.pathname.replace(/\/$/, '');
+  if (!allowed(ctx)) return new Response('Not Found', { status: 404 });
+
+  if (ctx.request.method === 'GET' && routePath === '/api/bridge/stream') {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        clients.add(controller);
+        sendEvent(controller, 'ping');
+        const timer = setInterval(() => {
+          try { sendEvent(controller, 'ping'); } catch { clients.delete(controller); clearInterval(timer); }
+        }, 20_000);
+        ctx.request.signal.addEventListener('abort', () => {
+          clearInterval(timer);
+          clients.delete(controller);
+          try { controller.close(); } catch { /* noop */ }
+        }, { once: true });
+      },
+      cancel(controller) { clients.delete(controller as unknown as BridgeController); },
+    });
+    return new Response(stream, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+        'X-Accel-Buffering': 'no',
+      },
+    });
+  }
+
+  if (ctx.request.method === 'POST' && routePath === '/api/bridge/cmd') {
+    let body: { action?: string; payload?: unknown; id?: string };
+    try { body = await ctx.request.json(); } catch { return Response.json({ id: null, ok: false, error: 'Invalid JSON' }, { status: 400 }); }
+    const { action, payload, id } = body;
+    const handler = action ? HANDLERS[action] : null;
+    if (!handler) return Response.json({ id, ok: false, error: `Unknown action: ${action}` }, { status: 400 });
+    try {
+      const result = await handler(payload ?? {});
+      if (action && MUTATING.has(action)) {
+        await runGenerate();
+        broadcast('reload');
+      }
+      return Response.json({ id, ok: true, result });
+    } catch (error) {
+      return Response.json({ id, ok: false, error: error instanceof Error ? error.message : String(error) }, { status: 500 });
+    }
+  }
+
+  return new Response('Not Found', { status: 404 });
+}
+
+export async function devBridgeMiddleware(ctx: APIContext, next: MiddlewareNext) {
+  const url = new URL(ctx.request.url);
+  if (!url.pathname.startsWith('/api/bridge/')) return next();
+  return handleDevBridgeRequest(ctx);
+}
+
+export const onRequest = devBridgeMiddleware;
+

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,0 +1,1 @@
+export { onRequest } from './devBridge';


### PR DESCRIPTION
### Motivation

- Consolidate the dev CMS bridge onto a single port using Astro middleware + SSE/fetch to avoid a separate WebSocket process and improve reliability during editing. 
- Keep existing functionality and design while adding navigation management (tree, DnD, CRUD) and an editor live preview to improve authoring UX. 
- Harden file operations by centralising handlers and adding path safety checks to prevent path traversal. 

### Description

- Extracted all bridge filesystem/generation logic into `scripts/bridgeHandlers.mjs` and exported `HANDLERS`, `MUTATING`, `runGenerate` and path constants, and added `assertSafe`, `handleListCustomPages`, `handleReadNavStructure`, `handleMoveEntry`, and `handleRenameEntry`. 
- Implemented same-port dev bridge with SSE and JSON command handling in `src/middleware/devBridge.ts` (SSE `/api/bridge/stream`, POST `/api/bridge/cmd`) with `import.meta.env.DEV` + `BRIDGE_ALLOWED_HOSTS` checks and reload broadcast on mutating actions. 
- Kept a temporary WebSocket fallback in `scripts/devBridge.mjs` but slimmed it to import handlers and add an `sse` middleware hook for the dev server. 
- Replaced the client WebSocket hook with `src/features/dev-panel/useDevBridge.ts` implementing a queued `fetch`-based command API plus a singleton `EventSource` with reconnect/backoff and status broadcasts, and added new bridge methods (`listCustomPages`, `readNavStructure`, `moveEntry`, `renameEntry`). 
- Added a Navigation panel `src/features/dev-panel/panels/NavPanel.tsx` and wired the new `nav` tab into `DevPanel.tsx`, including drag&drop move, create/rename/delete flows and modal UX using existing theme tokens. 
- Enhanced the Markdown editor in `DocsPanel.tsx` with three split modes (`editor` | `split` | `preview`), toolbar mode buttons, sessionStorage persistence (`hub:editor:splitMode`), and debounced live preview via `bridge.renderPreview`. 
- Added `.env.local.example` documenting `BRIDGE_ALLOWED_HOSTS`, created middleware index exports and `src/app/middleware.ts` to ensure the middleware is picked up in dev. 

### Testing

- Ran `npm run build` which completed successfully and produced the static build outputs. 
- Ran `npm run dev` and verified the dev server started and the bridge middleware reported readiness. 
- Verified API behavior with `curl -X POST 'http://localhost:4321/api/bridge/cmd/' -H 'Content-Type: application/json' -d '{"action":"ping","id":"test"}'` which returned a successful ping response. 
- Verified SSE stream with `timeout 2 curl -N 'http://localhost:4321/api/bridge/stream/'` which delivered a `ping` event; mutating actions trigger `reload` broadcasts. 
- Ran `npm run lint` which completed; pre-existing lint warnings remain but no new errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e498b46e4832b8abeed3d43ece3cd)